### PR TITLE
clean up on API handlers

### DIFF
--- a/app/cmd/signalsd/main.go
+++ b/app/cmd/signalsd/main.go
@@ -107,7 +107,7 @@ import (
 //	@tag.name			ISN details
 //	@tag.description	View information about the configured ISNs
 
-//	@tag.name			Signal definitions
+//	@tag.name			Signal types
 //	@tag.description	Define the format of the data being shared in an ISN
 
 // @tag.name			Service accounts

--- a/app/docs/docs.go
+++ b/app/docs/docs.go
@@ -119,6 +119,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3",
                         "description": "Account ID to disable",
                         "name": "account_id",
                         "in": "path",
@@ -171,6 +172,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3",
                         "description": "Account ID to enable",
                         "name": "account_id",
                         "in": "path",
@@ -246,7 +248,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.ServiceAccount"
+                                "$ref": "#/definitions/handlers.ServiceAccountDetails"
                             }
                         }
                     },
@@ -280,6 +282,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3",
                         "description": "Service Account ID",
                         "name": "id",
                         "in": "path",
@@ -290,7 +293,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/database.ServiceAccount"
+                            "$ref": "#/definitions/handlers.ServiceAccountDetails"
                         }
                     },
                     "400": {
@@ -338,7 +341,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.GetUsersRow"
+                                "$ref": "#/definitions/handlers.UserDetails"
                             }
                         }
                     },
@@ -383,7 +386,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/database.GetUserByIDRow"
+                            "$ref": "#/definitions/handlers.UserDetails"
                         }
                     },
                     "400": {
@@ -428,6 +431,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3",
                         "description": "User Account ID",
                         "name": "user_id",
                         "in": "path",
@@ -696,6 +700,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "550e8400-e29b-41d4-a716-446655440000",
                         "description": "One-time setup ID",
                         "name": "setup_id",
                         "in": "path",
@@ -740,7 +745,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.Isn"
+                                "$ref": "#/definitions/handlers.Isn"
                             }
                         }
                     }
@@ -796,6 +801,43 @@ const docTemplate = `{
             }
         },
         "/api/isn/{isn_slug}": {
+            "get": {
+                "description": "Returns details about the ISN",
+                "tags": [
+                    "ISN details"
+                ],
+                "summary": "Get an ISN configurationuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "isn slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.IsnAndLinkedInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "put": {
                 "security": [
                     {
@@ -864,7 +906,7 @@ const docTemplate = `{
                         "BearerAccessToken": []
                     }
                 ],
-                "description": "Get a list of all accounts (users and service accounts) that have permissions on the specified ISN.\nOnly ISN owners and site owners can view this information.",
+                "description": "Get a list of all accounts (users and service accounts) that have permissions on the specified ISN.\nOnly ISN admins and site owners can view this information.",
                 "tags": [
                     "ISN details"
                 ],
@@ -872,6 +914,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "sample-isn--example-org",
                         "description": "ISN slug",
                         "name": "isn_slug",
                         "in": "path",
@@ -884,7 +927,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.GetAccountsByIsnIDRow"
+                                "$ref": "#/definitions/handlers.IsnAccount"
                             }
                         }
                     },
@@ -988,17 +1031,44 @@ const docTemplate = `{
         },
         "/api/isn/{isn_slug}/signal_types": {
             "get": {
+                "description": "Get details for the signal types defined on the ISN",
                 "tags": [
-                    "ISN details"
+                    "Signal types"
                 ],
-                "summary": "Get the signal definitions",
+                "summary": "Get Signal types",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "ISN slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "sample-signal--example-org",
+                        "description": "signal type slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "0.0.1",
+                        "description": "version to be deleted",
+                        "name": "sem_ver",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.SignalType"
+                                "$ref": "#/definitions/handlers.SignalTypeDetail"
                             }
                         }
                     }
@@ -1010,14 +1080,14 @@ const docTemplate = `{
                         "BearerAccessToken": []
                     }
                 ],
-                "description": "A signal type describes a data set that is sharable over an ISN.  Setup the ISN before defining any signal defs.\nSignal types specify a record that can be shared over the ISN\n- Each type has a unique title\n- A URL-friendly slug is created based on the title supplied when you load the first version of a definition.\n- The title and slug fields can't be changed and it is not allowed to reuse a slug that was created by another account.\n- The field definition is held as an external JSON schema file\n\nSchema URL Requirements\n- Must be a valid JSON schema on a public github repo (e.g., https://github.com/org/repo/blob/2025.01.01/schema.json)\n- To disable schema validation, use: https://github.com/skip/validation/main/schema.json\n\nVersions\n- A signal type can have multiple versions - these share the same title/slug but have different JSON schemas\n- Use this endpoint to create the first version - the bump_type (major/minor/patch) determines the initial semver (1.0.0, 0.1.0 or 0.0.1)\n- Subsequent POSTs to this endpoint that reference a previously submitted title/slug but point to a different schema will increment the version\n\nSignal type definitions are referred to with a URL like this: http://{hostname}/api/isn/{isn_slug}/signal_types/{slug}/v{sem_ver}\n",
+                "description": "Signal types specify a record that can be shared over the ISN\n- Each type has a unique title and this is used to create a URL-friendly slug\n- The title and slug fields can't be changed and it is not allowed to reuse a slug that was created by another account.\n- The signal type fields are defined in an external JSON schema file and this schema file is used to validate signals before loading\n\nSchema URL Requirements\n- Must be a valid JSON schema on a public github repo (e.g., https://github.com/org/repo/blob/2025.01.01/schema.json)\n- To disable schema validation, use: https://github.com/skip/validation/main/schema.json\n\nVersions\n- A signal type can have multiple versions - these share the same title/slug but have different JSON schemas\n- Use this endpoint to create the first version - the bump_type (major/minor/patch) determines the initial semver (1.0.0, 0.1.0 or 0.0.1)\n- Subsequent POSTs to this endpoint that reference a previously submitted title/slug but point to a different schema will increment the version based on the supplied bump_type\n\nSignal type definitions are referred to with a URL like this: http://{hostname}/api/isn/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}\n",
                 "tags": [
-                    "Signal definitions"
+                    "Signal types"
                 ],
-                "summary": "Create signal type definition",
+                "summary": "Create signal type",
                 "parameters": [
                     {
-                        "description": "signal definition details",
+                        "description": "signal type details",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -1047,6 +1117,211 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/isn/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}": {
+            "get": {
+                "description": "Returns details about the signal type",
+                "tags": [
+                    "Signal types",
+                    "ISN details"
+                ],
+                "summary": "Get signal type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "ISN slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "sample-signal--example-org",
+                        "description": "signal definiton slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "0.0.1",
+                        "description": "version to be recieved",
+                        "name": "sem_ver",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SignalTypeDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAccessToken": []
+                    }
+                ],
+                "description": "users can mark the signal type as *in use/not in use* and update the description or link to the readme file\nSignal types marked as 'not in use' are not returned in signal searches and can not receive new signals",
+                "tags": [
+                    "Signal types"
+                ],
+                "summary": "Update signal type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "ISN slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "sample-signal--example-org",
+                        "description": "signal definiton slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "0.0.1",
+                        "description": "Sem ver",
+                        "name": "sem_ver",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "signal type details to be updated",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdateSignalTypeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAccessToken": []
+                    }
+                ],
+                "description": "Only signal types that have never been referenced by signals can be deleted",
+                "tags": [
+                    "Signal types"
+                ],
+                "summary": "Delete signal type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "ISN slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "sample-signal--example-org",
+                        "description": "signal type slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "0.0.1",
+                        "description": "version to be deleted",
+                        "name": "sem_ver",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/responses.ErrorResponse"
                         }
@@ -1192,185 +1467,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/isn/{isn_slug}/signal_types/{slug}/v{sem_ver}": {
-            "get": {
-                "tags": [
-                    "ISN details"
-                ],
-                "summary": "Get a signal definition",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "sample-signal--example-org",
-                        "description": "signal definiton slug",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "example": "0.0.1",
-                        "description": "version to be recieved",
-                        "name": "sem_ver",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.SignalTypeAndLinkedInfo"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAccessToken": []
-                    }
-                ],
-                "description": "users can mark the signal type as *in use/not in use* and update the description or link to the readme file\n\nIt is not allowed to update the schema url - instead users should create a new declaration with the same title and bump the version",
-                "tags": [
-                    "Signal definitions"
-                ],
-                "summary": "Update signal definition",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "sample-signal--example-org",
-                        "description": "signal definiton slug",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "example": "0.0.1",
-                        "description": "Sem ver",
-                        "name": "sem_ver",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "signal type details to be updated",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/handlers.UpdateSignalTypeRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAccessToken": []
-                    }
-                ],
-                "description": "Only signal types that have never been referenced by signals can be deleted",
-                "tags": [
-                    "Signal definitions"
-                ],
-                "summary": "Delete a signal definition",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "sample-signal--example-org",
-                        "description": "signal type slug",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "example": "0.0.1",
-                        "description": "version to be deleted",
-                        "name": "sem_ver",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/api/isn/{isn_slug}/transfer-ownership": {
             "put": {
                 "security": [
@@ -1416,45 +1512,6 @@ const docTemplate = `{
                     },
                     "403": {
                         "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/isn/{slug}": {
-            "get": {
-                "description": "Returns details about the ISN",
-                "tags": [
-                    "ISN details"
-                ],
-                "summary": "Get an ISN configurationuration",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "sample-isn--example-org",
-                        "description": "isn slug",
-                        "name": "isn_slug",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.IsnAndLinkedInfo"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/responses.ErrorResponse"
                         }
@@ -1690,6 +1747,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "sample-isn--example-org",
                         "description": "ISN slug",
                         "name": "isn_slug",
                         "in": "path",
@@ -1697,6 +1755,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "example": "67890684-3b14-42cf-b785-df28ce570400",
                         "description": "Batch ID",
                         "name": "batch_id",
                         "in": "path",
@@ -1738,7 +1797,7 @@ const docTemplate = `{
                         "BearerAccessToken": []
                     }
                 ],
-                "description": "Submit an array of signals for storage on the ISN\n- payloads must not mix signals of different types and is subject to the size limits defined on the site.\n- The client-supplied local_ref must uniquely identify each signal of the specified signal type that will be supplied by the account.\n- If a local reference is received more than once from an account for a specified signal_type it will be stored with a incremented version number.\n- Optionally a correlation_id can be supplied - this will link the signal to a previously received signal. The correlated signal does not need to be owned by the same account.\n- requests are only accepted for the open signal batch for this account/ISN.\n\n**Authentication**\n\nRequires a valid access token.\nThe claims in the access token list the ISNs and signal_types that the account is permitted to use.\n\nThis handler also checks that the signal_type/sem_ver in the url is also listed in the claims (this is to catch mistyped urls)\n\n**Validation and Processing**\n\nSignals are validated against the json schema specified for the signal type unless validation is disabled on the type definition.\nIndividual signal processing failures (validation errors, incorrect correlation ids, database errors) are recorded in the response but do not prevent other signals from being processed.\n\nWhen validation is disabled, basic checks are still done on the incoming data and the following issues create a 400 error and cause the entire payload to be rejected:\n- invalid json format\n- missing fields (the array of signals must be in a json object called signals, and content and local_ref must be present for each record).\n\n\n**Response Status Codes**\n- 200: All signals processed successfully\n- 207: Partial success (some signals succeeded, some failed)\n- 422: All signals failed processing (returns CreateSignalsResponse with detailed error information)\n- 400 / error_code = 'malformed_body': Invalid request format, authentication, or other request-level errors\n- 400: authentication, or other request-level errors\n- 500: Internal server errors\n\nInternal server errors cause the whole payload to be rejected.",
+                "description": "Submit an array of signals for storage on the ISN\n- payloads must not mix signals of different types and is subject to the size limits defined on the site.\n- The client-supplied local_ref must uniquely identify each signal of the specified signal type that will be supplied by the account.\n- If a local reference is received more than once from an account for a specified signal_type it will be stored with a incremented version number.\n- Optionally a correlation_id can be supplied - this will link the signal to a previously received signal. The correlated signal does not need to be owned by the same account.\n- requests are only accepted for the open signal batch for this account/ISN.\n\n**Authentication**\n\nRequires a valid access token.\nThe claims in the access token list the ISNs and signal_types that the account is permitted to use.\n\nThis handler also checks that the signal_type/sem_ver in the url is also listed in the claims (this is to catch mistyped urls)\n\n**Validation and Processing**\n\nSignals are validated against the json schema specified for the signal type unless validation is disabled on the type definition.\nIndividual signal processing failures (validation errors, incorrect correlation ids, database errors) are recorded in the response but do not prevent other signals from being processed.\n\nWhen validation is disabled, basic checks are still done on the incoming data and the following issues create a 400 error and cause the entire payload to be rejected:\n- invalid json format\n- missing fields (the array of signals must be in a json object called signals, and content and local_ref must be present for each record).\n\n\n**Response Status Codes**\n- 200: All signals processed successfully\n- 207: Partial success (some signals succeeded, some failed)\n- 422: All signals failed processing (the request was valid but all signals failed processing, e.g because they did not validate against the schema)\n- 400 / error_code = 'malformed_body': Invalid request format, authentication, or other request-level errors\n- 400: authentication, or other request-level errors\n- 500: Internal server errors\n\nInternal server errors cause the whole payload to be rejected.",
                 "tags": [
                     "Signal sharing"
                 ],
@@ -2061,229 +2120,6 @@ const docTemplate = `{
                 }
             }
         },
-        "database.GetAccountsByIsnIDRow": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "account_role": {
-                    "type": "string"
-                },
-                "account_type": {
-                    "type": "string"
-                },
-                "client_id": {
-                    "type": "string"
-                },
-                "client_organization": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_active": {
-                    "type": "boolean"
-                },
-                "isn_id": {
-                    "type": "string"
-                },
-                "permission": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.GetForDisplaySignalTypeByIsnIDRow": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "detail": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_in_use": {
-                    "type": "boolean"
-                },
-                "readme_url": {
-                    "type": "string"
-                },
-                "schema_url": {
-                    "type": "string"
-                },
-                "sem_ver": {
-                    "type": "string"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.GetForDisplayUserByIsnIDRow": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.GetUserByIDRow": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "user_role": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.GetUsersRow": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "user_role": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.Isn": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "detail": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_in_use": {
-                    "type": "boolean"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "user_account_id": {
-                    "type": "string"
-                },
-                "visibility": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.ServiceAccount": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "client_contact_email": {
-                    "type": "string"
-                },
-                "client_id": {
-                    "type": "string"
-                },
-                "client_organization": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.SignalType": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "detail": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_in_use": {
-                    "type": "boolean"
-                },
-                "isn_id": {
-                    "type": "string"
-                },
-                "readme_url": {
-                    "type": "string"
-                },
-                "schema_content": {
-                    "type": "string"
-                },
-                "schema_url": {
-                    "type": "string"
-                },
-                "sem_ver": {
-                    "type": "string"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
         "handlers.BatchStatus": {
             "type": "object",
             "properties": {
@@ -2423,7 +2259,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "bump_type": {
-                    "description": "this is used to increment semver for the signal definition",
+                    "description": "this is used to increment semver for the signal type",
                     "type": "string",
                     "enum": [
                         "major",
@@ -2619,41 +2455,127 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.IsnAndLinkedInfo": {
+        "handlers.Isn": {
             "type": "object",
             "properties": {
                 "created_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
                 },
                 "detail": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Sample ISN description"
                 },
                 "id": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
                 },
                 "is_in_use": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "example": true
+                },
+                "slug": {
+                    "type": "string",
+                    "example": "sample-isn--example-org"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Sample ISN @example.org"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "visibility": {
+                    "type": "string",
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
+                    "example": "private"
+                }
+            }
+        },
+        "handlers.IsnAccount": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
+                },
+                "account_role": {
+                    "type": "string",
+                    "enum": [
+                        "owner",
+                        "admin",
+                        "member"
+                    ],
+                    "example": "admin"
+                },
+                "account_type": {
+                    "type": "string",
+                    "enum": [
+                        "user",
+                        "service_account"
+                    ],
+                    "example": "user"
+                },
+                "client_id": {
+                    "type": "string",
+                    "example": "client-123"
+                },
+                "client_organization": {
+                    "type": "string",
+                    "example": "Example Organization"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "email": {
+                    "type": "string",
+                    "example": "user@example.com"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
+                },
+                "is_active": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "isn_id": {
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
+                },
+                "permission": {
+                    "type": "string",
+                    "enum": [
+                        "read",
+                        "write"
+                    ],
+                    "example": "write"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                }
+            }
+        },
+        "handlers.IsnAndLinkedInfo": {
+            "type": "object",
+            "properties": {
+                "isn": {
+                    "$ref": "#/definitions/handlers.Isn"
                 },
                 "signal_types": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/database.GetForDisplaySignalTypeByIsnIDRow"
+                        "$ref": "#/definitions/handlers.SignalType"
                     }
                 },
-                "slug": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
                 "user": {
-                    "$ref": "#/definitions/database.GetForDisplayUserByIsnIDRow"
-                },
-                "visibility": {
-                    "type": "string"
+                    "$ref": "#/definitions/handlers.User"
                 }
             }
         },
@@ -2685,6 +2607,35 @@ const docTemplate = `{
             "properties": {
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.ServiceAccountDetails": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
+                },
+                "client_contact_email": {
+                    "type": "string",
+                    "example": "contact@example.com"
+                },
+                "client_id": {
+                    "type": "string",
+                    "example": "client-123"
+                },
+                "client_organization": {
+                    "type": "string",
+                    "example": "Example Organization"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
                 }
             }
         },
@@ -2723,41 +2674,93 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.SignalTypeAndLinkedInfo": {
+        "handlers.SignalType": {
             "type": "object",
             "properties": {
                 "created_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
                 },
                 "detail": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Sample signal type description"
                 },
                 "id": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
                 },
                 "is_in_use": {
-                    "type": "boolean"
-                },
-                "isn": {
-                    "$ref": "#/definitions/database.Isn"
+                    "type": "boolean",
+                    "example": true
                 },
                 "readme_url": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "https://example.com/readme.md"
                 },
                 "schema_url": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "https://example.com/schema.json"
                 },
                 "sem_ver": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "1.0.0"
                 },
                 "slug": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "sample-signal-type"
                 },
                 "title": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Sample Signal Type"
                 },
                 "updated_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                }
+            }
+        },
+        "handlers.SignalTypeDetail": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "detail": {
+                    "type": "string",
+                    "example": "Sample signal type description"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
+                },
+                "is_in_use": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "readme_url": {
+                    "type": "string",
+                    "example": "https://github.com/user/project/blob/2025.01.01/readme.md"
+                },
+                "schema_url": {
+                    "type": "string",
+                    "example": "https://github.com/user/project/blob/2025.01.01/schema.json"
+                },
+                "sem_ver": {
+                    "type": "string",
+                    "example": "1.0.0"
+                },
+                "slug": {
+                    "type": "string",
+                    "example": "sample-signal-type"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Sample Signal Type"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
                 }
             }
         },
@@ -2894,6 +2897,53 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.User": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                }
+            }
+        },
+        "handlers.UserDetails": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "email": {
+                    "type": "string",
+                    "example": "user@example.com"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "user_role": {
+                    "type": "string",
+                    "enum": [
+                        "owner",
+                        "admin",
+                        "member"
+                    ],
+                    "example": "admin"
+                }
+            }
+        },
         "handlers.WithdrawSignalRequest": {
             "type": "object",
             "properties": {
@@ -2969,7 +3019,7 @@ const docTemplate = `{
         },
         {
             "description": "Define the format of the data being shared in an ISN",
-            "name": "Signal definitions"
+            "name": "Signal types"
         },
         {
             "description": "Manage service account end points",

--- a/app/docs/swagger.json
+++ b/app/docs/swagger.json
@@ -110,6 +110,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3",
                         "description": "Account ID to disable",
                         "name": "account_id",
                         "in": "path",
@@ -162,6 +163,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3",
                         "description": "Account ID to enable",
                         "name": "account_id",
                         "in": "path",
@@ -237,7 +239,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.ServiceAccount"
+                                "$ref": "#/definitions/handlers.ServiceAccountDetails"
                             }
                         }
                     },
@@ -271,6 +273,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3",
                         "description": "Service Account ID",
                         "name": "id",
                         "in": "path",
@@ -281,7 +284,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/database.ServiceAccount"
+                            "$ref": "#/definitions/handlers.ServiceAccountDetails"
                         }
                     },
                     "400": {
@@ -329,7 +332,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.GetUsersRow"
+                                "$ref": "#/definitions/handlers.UserDetails"
                             }
                         }
                     },
@@ -374,7 +377,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/database.GetUserByIDRow"
+                            "$ref": "#/definitions/handlers.UserDetails"
                         }
                     },
                     "400": {
@@ -419,6 +422,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3",
                         "description": "User Account ID",
                         "name": "user_id",
                         "in": "path",
@@ -687,6 +691,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "550e8400-e29b-41d4-a716-446655440000",
                         "description": "One-time setup ID",
                         "name": "setup_id",
                         "in": "path",
@@ -731,7 +736,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.Isn"
+                                "$ref": "#/definitions/handlers.Isn"
                             }
                         }
                     }
@@ -787,6 +792,43 @@
             }
         },
         "/api/isn/{isn_slug}": {
+            "get": {
+                "description": "Returns details about the ISN",
+                "tags": [
+                    "ISN details"
+                ],
+                "summary": "Get an ISN configurationuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "isn slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.IsnAndLinkedInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "put": {
                 "security": [
                     {
@@ -855,7 +897,7 @@
                         "BearerAccessToken": []
                     }
                 ],
-                "description": "Get a list of all accounts (users and service accounts) that have permissions on the specified ISN.\nOnly ISN owners and site owners can view this information.",
+                "description": "Get a list of all accounts (users and service accounts) that have permissions on the specified ISN.\nOnly ISN admins and site owners can view this information.",
                 "tags": [
                     "ISN details"
                 ],
@@ -863,6 +905,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "sample-isn--example-org",
                         "description": "ISN slug",
                         "name": "isn_slug",
                         "in": "path",
@@ -875,7 +918,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.GetAccountsByIsnIDRow"
+                                "$ref": "#/definitions/handlers.IsnAccount"
                             }
                         }
                     },
@@ -979,17 +1022,44 @@
         },
         "/api/isn/{isn_slug}/signal_types": {
             "get": {
+                "description": "Get details for the signal types defined on the ISN",
                 "tags": [
-                    "ISN details"
+                    "Signal types"
                 ],
-                "summary": "Get the signal definitions",
+                "summary": "Get Signal types",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "ISN slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "sample-signal--example-org",
+                        "description": "signal type slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "0.0.1",
+                        "description": "version to be deleted",
+                        "name": "sem_ver",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/database.SignalType"
+                                "$ref": "#/definitions/handlers.SignalTypeDetail"
                             }
                         }
                     }
@@ -1001,14 +1071,14 @@
                         "BearerAccessToken": []
                     }
                 ],
-                "description": "A signal type describes a data set that is sharable over an ISN.  Setup the ISN before defining any signal defs.\nSignal types specify a record that can be shared over the ISN\n- Each type has a unique title\n- A URL-friendly slug is created based on the title supplied when you load the first version of a definition.\n- The title and slug fields can't be changed and it is not allowed to reuse a slug that was created by another account.\n- The field definition is held as an external JSON schema file\n\nSchema URL Requirements\n- Must be a valid JSON schema on a public github repo (e.g., https://github.com/org/repo/blob/2025.01.01/schema.json)\n- To disable schema validation, use: https://github.com/skip/validation/main/schema.json\n\nVersions\n- A signal type can have multiple versions - these share the same title/slug but have different JSON schemas\n- Use this endpoint to create the first version - the bump_type (major/minor/patch) determines the initial semver (1.0.0, 0.1.0 or 0.0.1)\n- Subsequent POSTs to this endpoint that reference a previously submitted title/slug but point to a different schema will increment the version\n\nSignal type definitions are referred to with a URL like this: http://{hostname}/api/isn/{isn_slug}/signal_types/{slug}/v{sem_ver}\n",
+                "description": "Signal types specify a record that can be shared over the ISN\n- Each type has a unique title and this is used to create a URL-friendly slug\n- The title and slug fields can't be changed and it is not allowed to reuse a slug that was created by another account.\n- The signal type fields are defined in an external JSON schema file and this schema file is used to validate signals before loading\n\nSchema URL Requirements\n- Must be a valid JSON schema on a public github repo (e.g., https://github.com/org/repo/blob/2025.01.01/schema.json)\n- To disable schema validation, use: https://github.com/skip/validation/main/schema.json\n\nVersions\n- A signal type can have multiple versions - these share the same title/slug but have different JSON schemas\n- Use this endpoint to create the first version - the bump_type (major/minor/patch) determines the initial semver (1.0.0, 0.1.0 or 0.0.1)\n- Subsequent POSTs to this endpoint that reference a previously submitted title/slug but point to a different schema will increment the version based on the supplied bump_type\n\nSignal type definitions are referred to with a URL like this: http://{hostname}/api/isn/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}\n",
                 "tags": [
-                    "Signal definitions"
+                    "Signal types"
                 ],
-                "summary": "Create signal type definition",
+                "summary": "Create signal type",
                 "parameters": [
                     {
-                        "description": "signal definition details",
+                        "description": "signal type details",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -1038,6 +1108,211 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/isn/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}": {
+            "get": {
+                "description": "Returns details about the signal type",
+                "tags": [
+                    "Signal types",
+                    "ISN details"
+                ],
+                "summary": "Get signal type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "ISN slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "sample-signal--example-org",
+                        "description": "signal definiton slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "0.0.1",
+                        "description": "version to be recieved",
+                        "name": "sem_ver",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SignalTypeDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAccessToken": []
+                    }
+                ],
+                "description": "users can mark the signal type as *in use/not in use* and update the description or link to the readme file\nSignal types marked as 'not in use' are not returned in signal searches and can not receive new signals",
+                "tags": [
+                    "Signal types"
+                ],
+                "summary": "Update signal type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "ISN slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "sample-signal--example-org",
+                        "description": "signal definiton slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "0.0.1",
+                        "description": "Sem ver",
+                        "name": "sem_ver",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "signal type details to be updated",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdateSignalTypeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAccessToken": []
+                    }
+                ],
+                "description": "Only signal types that have never been referenced by signals can be deleted",
+                "tags": [
+                    "Signal types"
+                ],
+                "summary": "Delete signal type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "sample-isn--example-org",
+                        "description": "ISN slug",
+                        "name": "isn_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "sample-signal--example-org",
+                        "description": "signal type slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "0.0.1",
+                        "description": "version to be deleted",
+                        "name": "sem_ver",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/responses.ErrorResponse"
                         }
@@ -1183,185 +1458,6 @@
                 }
             }
         },
-        "/api/isn/{isn_slug}/signal_types/{slug}/v{sem_ver}": {
-            "get": {
-                "tags": [
-                    "ISN details"
-                ],
-                "summary": "Get a signal definition",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "sample-signal--example-org",
-                        "description": "signal definiton slug",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "example": "0.0.1",
-                        "description": "version to be recieved",
-                        "name": "sem_ver",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.SignalTypeAndLinkedInfo"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAccessToken": []
-                    }
-                ],
-                "description": "users can mark the signal type as *in use/not in use* and update the description or link to the readme file\n\nIt is not allowed to update the schema url - instead users should create a new declaration with the same title and bump the version",
-                "tags": [
-                    "Signal definitions"
-                ],
-                "summary": "Update signal definition",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "sample-signal--example-org",
-                        "description": "signal definiton slug",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "example": "0.0.1",
-                        "description": "Sem ver",
-                        "name": "sem_ver",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "signal type details to be updated",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/handlers.UpdateSignalTypeRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAccessToken": []
-                    }
-                ],
-                "description": "Only signal types that have never been referenced by signals can be deleted",
-                "tags": [
-                    "Signal definitions"
-                ],
-                "summary": "Delete a signal definition",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "sample-signal--example-org",
-                        "description": "signal type slug",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "example": "0.0.1",
-                        "description": "version to be deleted",
-                        "name": "sem_ver",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/api/isn/{isn_slug}/transfer-ownership": {
             "put": {
                 "security": [
@@ -1407,45 +1503,6 @@
                     },
                     "403": {
                         "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/isn/{slug}": {
-            "get": {
-                "description": "Returns details about the ISN",
-                "tags": [
-                    "ISN details"
-                ],
-                "summary": "Get an ISN configurationuration",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "sample-isn--example-org",
-                        "description": "isn slug",
-                        "name": "isn_slug",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.IsnAndLinkedInfo"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/responses.ErrorResponse"
                         }
@@ -1681,6 +1738,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "example": "sample-isn--example-org",
                         "description": "ISN slug",
                         "name": "isn_slug",
                         "in": "path",
@@ -1688,6 +1746,7 @@
                     },
                     {
                         "type": "string",
+                        "example": "67890684-3b14-42cf-b785-df28ce570400",
                         "description": "Batch ID",
                         "name": "batch_id",
                         "in": "path",
@@ -1729,7 +1788,7 @@
                         "BearerAccessToken": []
                     }
                 ],
-                "description": "Submit an array of signals for storage on the ISN\n- payloads must not mix signals of different types and is subject to the size limits defined on the site.\n- The client-supplied local_ref must uniquely identify each signal of the specified signal type that will be supplied by the account.\n- If a local reference is received more than once from an account for a specified signal_type it will be stored with a incremented version number.\n- Optionally a correlation_id can be supplied - this will link the signal to a previously received signal. The correlated signal does not need to be owned by the same account.\n- requests are only accepted for the open signal batch for this account/ISN.\n\n**Authentication**\n\nRequires a valid access token.\nThe claims in the access token list the ISNs and signal_types that the account is permitted to use.\n\nThis handler also checks that the signal_type/sem_ver in the url is also listed in the claims (this is to catch mistyped urls)\n\n**Validation and Processing**\n\nSignals are validated against the json schema specified for the signal type unless validation is disabled on the type definition.\nIndividual signal processing failures (validation errors, incorrect correlation ids, database errors) are recorded in the response but do not prevent other signals from being processed.\n\nWhen validation is disabled, basic checks are still done on the incoming data and the following issues create a 400 error and cause the entire payload to be rejected:\n- invalid json format\n- missing fields (the array of signals must be in a json object called signals, and content and local_ref must be present for each record).\n\n\n**Response Status Codes**\n- 200: All signals processed successfully\n- 207: Partial success (some signals succeeded, some failed)\n- 422: All signals failed processing (returns CreateSignalsResponse with detailed error information)\n- 400 / error_code = 'malformed_body': Invalid request format, authentication, or other request-level errors\n- 400: authentication, or other request-level errors\n- 500: Internal server errors\n\nInternal server errors cause the whole payload to be rejected.",
+                "description": "Submit an array of signals for storage on the ISN\n- payloads must not mix signals of different types and is subject to the size limits defined on the site.\n- The client-supplied local_ref must uniquely identify each signal of the specified signal type that will be supplied by the account.\n- If a local reference is received more than once from an account for a specified signal_type it will be stored with a incremented version number.\n- Optionally a correlation_id can be supplied - this will link the signal to a previously received signal. The correlated signal does not need to be owned by the same account.\n- requests are only accepted for the open signal batch for this account/ISN.\n\n**Authentication**\n\nRequires a valid access token.\nThe claims in the access token list the ISNs and signal_types that the account is permitted to use.\n\nThis handler also checks that the signal_type/sem_ver in the url is also listed in the claims (this is to catch mistyped urls)\n\n**Validation and Processing**\n\nSignals are validated against the json schema specified for the signal type unless validation is disabled on the type definition.\nIndividual signal processing failures (validation errors, incorrect correlation ids, database errors) are recorded in the response but do not prevent other signals from being processed.\n\nWhen validation is disabled, basic checks are still done on the incoming data and the following issues create a 400 error and cause the entire payload to be rejected:\n- invalid json format\n- missing fields (the array of signals must be in a json object called signals, and content and local_ref must be present for each record).\n\n\n**Response Status Codes**\n- 200: All signals processed successfully\n- 207: Partial success (some signals succeeded, some failed)\n- 422: All signals failed processing (the request was valid but all signals failed processing, e.g because they did not validate against the schema)\n- 400 / error_code = 'malformed_body': Invalid request format, authentication, or other request-level errors\n- 400: authentication, or other request-level errors\n- 500: Internal server errors\n\nInternal server errors cause the whole payload to be rejected.",
                 "tags": [
                     "Signal sharing"
                 ],
@@ -2052,229 +2111,6 @@
                 }
             }
         },
-        "database.GetAccountsByIsnIDRow": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "account_role": {
-                    "type": "string"
-                },
-                "account_type": {
-                    "type": "string"
-                },
-                "client_id": {
-                    "type": "string"
-                },
-                "client_organization": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_active": {
-                    "type": "boolean"
-                },
-                "isn_id": {
-                    "type": "string"
-                },
-                "permission": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.GetForDisplaySignalTypeByIsnIDRow": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "detail": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_in_use": {
-                    "type": "boolean"
-                },
-                "readme_url": {
-                    "type": "string"
-                },
-                "schema_url": {
-                    "type": "string"
-                },
-                "sem_ver": {
-                    "type": "string"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.GetForDisplayUserByIsnIDRow": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.GetUserByIDRow": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "user_role": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.GetUsersRow": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "user_role": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.Isn": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "detail": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_in_use": {
-                    "type": "boolean"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "user_account_id": {
-                    "type": "string"
-                },
-                "visibility": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.ServiceAccount": {
-            "type": "object",
-            "properties": {
-                "account_id": {
-                    "type": "string"
-                },
-                "client_contact_email": {
-                    "type": "string"
-                },
-                "client_id": {
-                    "type": "string"
-                },
-                "client_organization": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "database.SignalType": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "detail": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_in_use": {
-                    "type": "boolean"
-                },
-                "isn_id": {
-                    "type": "string"
-                },
-                "readme_url": {
-                    "type": "string"
-                },
-                "schema_content": {
-                    "type": "string"
-                },
-                "schema_url": {
-                    "type": "string"
-                },
-                "sem_ver": {
-                    "type": "string"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
         "handlers.BatchStatus": {
             "type": "object",
             "properties": {
@@ -2414,7 +2250,7 @@
             "type": "object",
             "properties": {
                 "bump_type": {
-                    "description": "this is used to increment semver for the signal definition",
+                    "description": "this is used to increment semver for the signal type",
                     "type": "string",
                     "enum": [
                         "major",
@@ -2610,41 +2446,127 @@
                 }
             }
         },
-        "handlers.IsnAndLinkedInfo": {
+        "handlers.Isn": {
             "type": "object",
             "properties": {
                 "created_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
                 },
                 "detail": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Sample ISN description"
                 },
                 "id": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
                 },
                 "is_in_use": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "example": true
+                },
+                "slug": {
+                    "type": "string",
+                    "example": "sample-isn--example-org"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Sample ISN @example.org"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "visibility": {
+                    "type": "string",
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
+                    "example": "private"
+                }
+            }
+        },
+        "handlers.IsnAccount": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
+                },
+                "account_role": {
+                    "type": "string",
+                    "enum": [
+                        "owner",
+                        "admin",
+                        "member"
+                    ],
+                    "example": "admin"
+                },
+                "account_type": {
+                    "type": "string",
+                    "enum": [
+                        "user",
+                        "service_account"
+                    ],
+                    "example": "user"
+                },
+                "client_id": {
+                    "type": "string",
+                    "example": "client-123"
+                },
+                "client_organization": {
+                    "type": "string",
+                    "example": "Example Organization"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "email": {
+                    "type": "string",
+                    "example": "user@example.com"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
+                },
+                "is_active": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "isn_id": {
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
+                },
+                "permission": {
+                    "type": "string",
+                    "enum": [
+                        "read",
+                        "write"
+                    ],
+                    "example": "write"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                }
+            }
+        },
+        "handlers.IsnAndLinkedInfo": {
+            "type": "object",
+            "properties": {
+                "isn": {
+                    "$ref": "#/definitions/handlers.Isn"
                 },
                 "signal_types": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/database.GetForDisplaySignalTypeByIsnIDRow"
+                        "$ref": "#/definitions/handlers.SignalType"
                     }
                 },
-                "slug": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
                 "user": {
-                    "$ref": "#/definitions/database.GetForDisplayUserByIsnIDRow"
-                },
-                "visibility": {
-                    "type": "string"
+                    "$ref": "#/definitions/handlers.User"
                 }
             }
         },
@@ -2676,6 +2598,35 @@
             "properties": {
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.ServiceAccountDetails": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
+                },
+                "client_contact_email": {
+                    "type": "string",
+                    "example": "contact@example.com"
+                },
+                "client_id": {
+                    "type": "string",
+                    "example": "client-123"
+                },
+                "client_organization": {
+                    "type": "string",
+                    "example": "Example Organization"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
                 }
             }
         },
@@ -2714,41 +2665,93 @@
                 }
             }
         },
-        "handlers.SignalTypeAndLinkedInfo": {
+        "handlers.SignalType": {
             "type": "object",
             "properties": {
                 "created_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
                 },
                 "detail": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Sample signal type description"
                 },
                 "id": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
                 },
                 "is_in_use": {
-                    "type": "boolean"
-                },
-                "isn": {
-                    "$ref": "#/definitions/database.Isn"
+                    "type": "boolean",
+                    "example": true
                 },
                 "readme_url": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "https://example.com/readme.md"
                 },
                 "schema_url": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "https://example.com/schema.json"
                 },
                 "sem_ver": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "1.0.0"
                 },
                 "slug": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "sample-signal-type"
                 },
                 "title": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Sample Signal Type"
                 },
                 "updated_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                }
+            }
+        },
+        "handlers.SignalTypeDetail": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "detail": {
+                    "type": "string",
+                    "example": "Sample signal type description"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "67890684-3b14-42cf-b785-df28ce570400"
+                },
+                "is_in_use": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "readme_url": {
+                    "type": "string",
+                    "example": "https://github.com/user/project/blob/2025.01.01/readme.md"
+                },
+                "schema_url": {
+                    "type": "string",
+                    "example": "https://github.com/user/project/blob/2025.01.01/schema.json"
+                },
+                "sem_ver": {
+                    "type": "string",
+                    "example": "1.0.0"
+                },
+                "slug": {
+                    "type": "string",
+                    "example": "sample-signal-type"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Sample Signal Type"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
                 }
             }
         },
@@ -2885,6 +2888,53 @@
                 }
             }
         },
+        "handlers.User": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                }
+            }
+        },
+        "handlers.UserDetails": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "email": {
+                    "type": "string",
+                    "example": "user@example.com"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2025-06-03T13:47:47.331787+01:00"
+                },
+                "user_role": {
+                    "type": "string",
+                    "enum": [
+                        "owner",
+                        "admin",
+                        "member"
+                    ],
+                    "example": "admin"
+                }
+            }
+        },
         "handlers.WithdrawSignalRequest": {
             "type": "object",
             "properties": {
@@ -2960,7 +3010,7 @@
         },
         {
             "description": "Define the format of the data being shared in an ISN",
-            "name": "Signal definitions"
+            "name": "Signal types"
         },
         {
             "description": "Manage service account end points",

--- a/app/docs/swagger.yaml
+++ b/app/docs/swagger.yaml
@@ -99,152 +99,6 @@ definitions:
           type: string
         type: array
     type: object
-  database.GetAccountsByIsnIDRow:
-    properties:
-      account_id:
-        type: string
-      account_role:
-        type: string
-      account_type:
-        type: string
-      client_id:
-        type: string
-      client_organization:
-        type: string
-      created_at:
-        type: string
-      email:
-        type: string
-      id:
-        type: string
-      is_active:
-        type: boolean
-      isn_id:
-        type: string
-      permission:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  database.GetForDisplaySignalTypeByIsnIDRow:
-    properties:
-      created_at:
-        type: string
-      detail:
-        type: string
-      id:
-        type: string
-      is_in_use:
-        type: boolean
-      readme_url:
-        type: string
-      schema_url:
-        type: string
-      sem_ver:
-        type: string
-      slug:
-        type: string
-      title:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  database.GetForDisplayUserByIsnIDRow:
-    properties:
-      account_id:
-        type: string
-      created_at:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  database.GetUserByIDRow:
-    properties:
-      account_id:
-        type: string
-      created_at:
-        type: string
-      email:
-        type: string
-      user_role:
-        type: string
-    type: object
-  database.GetUsersRow:
-    properties:
-      account_id:
-        type: string
-      created_at:
-        type: string
-      email:
-        type: string
-      updated_at:
-        type: string
-      user_role:
-        type: string
-    type: object
-  database.Isn:
-    properties:
-      created_at:
-        type: string
-      detail:
-        type: string
-      id:
-        type: string
-      is_in_use:
-        type: boolean
-      slug:
-        type: string
-      title:
-        type: string
-      updated_at:
-        type: string
-      user_account_id:
-        type: string
-      visibility:
-        type: string
-    type: object
-  database.ServiceAccount:
-    properties:
-      account_id:
-        type: string
-      client_contact_email:
-        type: string
-      client_id:
-        type: string
-      client_organization:
-        type: string
-      created_at:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  database.SignalType:
-    properties:
-      created_at:
-        type: string
-      detail:
-        type: string
-      id:
-        type: string
-      is_in_use:
-        type: boolean
-      isn_id:
-        type: string
-      readme_url:
-        type: string
-      schema_content:
-        type: string
-      schema_url:
-        type: string
-      sem_ver:
-        type: string
-      slug:
-        type: string
-      title:
-        type: string
-      updated_at:
-        type: string
-    type: object
   handlers.BatchStatus:
     properties:
       failed_count:
@@ -341,7 +195,7 @@ definitions:
   handlers.CreateSignalTypeRequest:
     properties:
       bump_type:
-        description: this is used to increment semver for the signal definition
+        description: this is used to increment semver for the signal type
         enum:
         - major
         - minor
@@ -480,30 +334,95 @@ definitions:
       local_ref:
         type: string
     type: object
-  handlers.IsnAndLinkedInfo:
+  handlers.Isn:
     properties:
       created_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
         type: string
       detail:
+        example: Sample ISN description
         type: string
       id:
+        example: 67890684-3b14-42cf-b785-df28ce570400
         type: string
       is_in_use:
+        example: true
         type: boolean
-      signal_types:
-        items:
-          $ref: '#/definitions/database.GetForDisplaySignalTypeByIsnIDRow'
-        type: array
       slug:
+        example: sample-isn--example-org
         type: string
       title:
+        example: Sample ISN @example.org
         type: string
       updated_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
         type: string
-      user:
-        $ref: '#/definitions/database.GetForDisplayUserByIsnIDRow'
       visibility:
+        enum:
+        - public
+        - private
+        example: private
         type: string
+    type: object
+  handlers.IsnAccount:
+    properties:
+      account_id:
+        example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
+        type: string
+      account_role:
+        enum:
+        - owner
+        - admin
+        - member
+        example: admin
+        type: string
+      account_type:
+        enum:
+        - user
+        - service_account
+        example: user
+        type: string
+      client_id:
+        example: client-123
+        type: string
+      client_organization:
+        example: Example Organization
+        type: string
+      created_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+      email:
+        example: user@example.com
+        type: string
+      id:
+        example: 67890684-3b14-42cf-b785-df28ce570400
+        type: string
+      is_active:
+        example: true
+        type: boolean
+      isn_id:
+        example: 67890684-3b14-42cf-b785-df28ce570400
+        type: string
+      permission:
+        enum:
+        - read
+        - write
+        example: write
+        type: string
+      updated_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+    type: object
+  handlers.IsnAndLinkedInfo:
+    properties:
+      isn:
+        $ref: '#/definitions/handlers.Isn'
+      signal_types:
+        items:
+          $ref: '#/definitions/handlers.SignalType'
+        type: array
+      user:
+        $ref: '#/definitions/handlers.User'
     type: object
   handlers.LoginRequest:
     properties:
@@ -524,6 +443,27 @@ definitions:
   handlers.ResetUserPasswordResponse:
     properties:
       message:
+        type: string
+    type: object
+  handlers.ServiceAccountDetails:
+    properties:
+      account_id:
+        example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
+        type: string
+      client_contact_email:
+        example: contact@example.com
+        type: string
+      client_id:
+        example: client-123
+        type: string
+      client_organization:
+        example: Example Organization
+        type: string
+      created_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+      updated_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
         type: string
     type: object
   handlers.ServiceAccountRotateResponse:
@@ -551,29 +491,70 @@ definitions:
         example: dGhpcyBpcyBhIHNlY3JldA
         type: string
     type: object
-  handlers.SignalTypeAndLinkedInfo:
+  handlers.SignalType:
     properties:
       created_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
         type: string
       detail:
+        example: Sample signal type description
         type: string
       id:
+        example: 67890684-3b14-42cf-b785-df28ce570400
         type: string
       is_in_use:
+        example: true
         type: boolean
-      isn:
-        $ref: '#/definitions/database.Isn'
       readme_url:
+        example: https://example.com/readme.md
         type: string
       schema_url:
+        example: https://example.com/schema.json
         type: string
       sem_ver:
+        example: 1.0.0
         type: string
       slug:
+        example: sample-signal-type
         type: string
       title:
+        example: Sample Signal Type
         type: string
       updated_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+    type: object
+  handlers.SignalTypeDetail:
+    properties:
+      created_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+      detail:
+        example: Sample signal type description
+        type: string
+      id:
+        example: 67890684-3b14-42cf-b785-df28ce570400
+        type: string
+      is_in_use:
+        example: true
+        type: boolean
+      readme_url:
+        example: https://github.com/user/project/blob/2025.01.01/readme.md
+        type: string
+      schema_url:
+        example: https://github.com/user/project/blob/2025.01.01/schema.json
+        type: string
+      sem_ver:
+        example: 1.0.0
+        type: string
+      slug:
+        example: sample-signal-type
+        type: string
+      title:
+        example: Sample Signal Type
+        type: string
+      updated_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
         type: string
     type: object
   handlers.SignalVersionDoc:
@@ -670,6 +651,40 @@ definitions:
       readme_url:
         description: 'README file URL: must be a GitHub URL ending in .md'
         example: https://github.com/user/project/blob/2025.01.01/readme.md
+        type: string
+    type: object
+  handlers.User:
+    properties:
+      account_id:
+        example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
+        type: string
+      created_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+      updated_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+    type: object
+  handlers.UserDetails:
+    properties:
+      account_id:
+        example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
+        type: string
+      created_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+      email:
+        example: user@example.com
+        type: string
+      updated_at:
+        example: "2025-06-03T13:47:47.331787+01:00"
+        type: string
+      user_role:
+        enum:
+        - owner
+        - admin
+        - member
+        example: admin
         type: string
     type: object
   handlers.WithdrawSignalRequest:
@@ -840,6 +855,7 @@ paths:
         Only owners and admins can disable accounts.
       parameters:
       - description: Account ID to disable
+        example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
         in: path
         name: account_id
         required: true
@@ -881,6 +897,7 @@ paths:
         Only owners and admins can enable accounts.
       parameters:
       - description: Account ID to enable
+        example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
         in: path
         name: account_id
         required: true
@@ -934,7 +951,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/database.ServiceAccount'
+              $ref: '#/definitions/handlers.ServiceAccountDetails'
             type: array
         "401":
           description: 'Authentication failed '
@@ -956,6 +973,7 @@ paths:
         Only owners and admins can view service account details.
       parameters:
       - description: Service Account ID
+        example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
         in: path
         name: id
         required: true
@@ -964,7 +982,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/database.ServiceAccount'
+            $ref: '#/definitions/handlers.ServiceAccountDetails'
         "400":
           description: Invalid service account ID format
           schema:
@@ -995,7 +1013,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/database.GetUsersRow'
+              $ref: '#/definitions/handlers.UserDetails'
             type: array
         "401":
           description: 'Authentication failed '
@@ -1025,7 +1043,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/database.GetUserByIDRow'
+            $ref: '#/definitions/handlers.UserDetails'
         "400":
           description: Invalid user ID format
           schema:
@@ -1053,6 +1071,7 @@ paths:
         the user has forgotten their password)
       parameters:
       - description: User Account ID
+        example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
         in: path
         name: user_id
         required: true
@@ -1256,6 +1275,7 @@ paths:
         The setup url is only valid for 48 hours.
       parameters:
       - description: One-time setup ID
+        example: 550e8400-e29b-41d4-a716-446655440000
         in: path
         name: setup_id
         required: true
@@ -1286,7 +1306,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/database.Isn'
+              $ref: '#/definitions/handlers.Isn'
             type: array
       summary: Get the ISNs
       tags:
@@ -1329,6 +1349,31 @@ paths:
       tags:
       - ISN configuration
   /api/isn/{isn_slug}:
+    get:
+      description: Returns details about the ISN
+      parameters:
+      - description: isn slug
+        example: sample-isn--example-org
+        in: path
+        name: isn_slug
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.IsnAndLinkedInfo'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      summary: Get an ISN configurationuration
+      tags:
+      - ISN details
     put:
       description: |-
         Update the ISN details
@@ -1374,9 +1419,10 @@ paths:
     get:
       description: |-
         Get a list of all accounts (users and service accounts) that have permissions on the specified ISN.
-        Only ISN owners and site owners can view this information.
+        Only ISN admins and site owners can view this information.
       parameters:
       - description: ISN slug
+        example: sample-isn--example-org
         in: path
         name: isn_slug
         required: true
@@ -1386,7 +1432,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/database.GetAccountsByIsnIDRow'
+              $ref: '#/definitions/handlers.IsnAccount'
             type: array
         "400":
           description: Bad Request
@@ -1468,24 +1514,42 @@ paths:
       - Signal sharing
   /api/isn/{isn_slug}/signal_types:
     get:
+      description: Get details for the signal types defined on the ISN
+      parameters:
+      - description: ISN slug
+        example: sample-isn--example-org
+        in: path
+        name: isn_slug
+        required: true
+        type: string
+      - description: signal type slug
+        example: sample-signal--example-org
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: version to be deleted
+        example: 0.0.1
+        in: path
+        name: sem_ver
+        required: true
+        type: string
       responses:
         "200":
           description: OK
           schema:
             items:
-              $ref: '#/definitions/database.SignalType'
+              $ref: '#/definitions/handlers.SignalTypeDetail'
             type: array
-      summary: Get the signal definitions
+      summary: Get Signal types
       tags:
-      - ISN details
+      - Signal types
     post:
       description: |
-        A signal type describes a data set that is sharable over an ISN.  Setup the ISN before defining any signal defs.
         Signal types specify a record that can be shared over the ISN
-        - Each type has a unique title
-        - A URL-friendly slug is created based on the title supplied when you load the first version of a definition.
+        - Each type has a unique title and this is used to create a URL-friendly slug
         - The title and slug fields can't be changed and it is not allowed to reuse a slug that was created by another account.
-        - The field definition is held as an external JSON schema file
+        - The signal type fields are defined in an external JSON schema file and this schema file is used to validate signals before loading
 
         Schema URL Requirements
         - Must be a valid JSON schema on a public github repo (e.g., https://github.com/org/repo/blob/2025.01.01/schema.json)
@@ -1494,11 +1558,11 @@ paths:
         Versions
         - A signal type can have multiple versions - these share the same title/slug but have different JSON schemas
         - Use this endpoint to create the first version - the bump_type (major/minor/patch) determines the initial semver (1.0.0, 0.1.0 or 0.0.1)
-        - Subsequent POSTs to this endpoint that reference a previously submitted title/slug but point to a different schema will increment the version
+        - Subsequent POSTs to this endpoint that reference a previously submitted title/slug but point to a different schema will increment the version based on the supplied bump_type
 
-        Signal type definitions are referred to with a URL like this: http://{hostname}/api/isn/{isn_slug}/signal_types/{slug}/v{sem_ver}
+        Signal type definitions are referred to with a URL like this: http://{hostname}/api/isn/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}
       parameters:
-      - description: signal definition details
+      - description: signal type details
         in: body
         name: request
         required: true
@@ -1523,9 +1587,151 @@ paths:
             $ref: '#/definitions/responses.ErrorResponse'
       security:
       - BearerAccessToken: []
-      summary: Create signal type definition
+      summary: Create signal type
       tags:
-      - Signal definitions
+      - Signal types
+  /api/isn/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}:
+    delete:
+      description: Only signal types that have never been referenced by signals can
+        be deleted
+      parameters:
+      - description: ISN slug
+        example: sample-isn--example-org
+        in: path
+        name: isn_slug
+        required: true
+        type: string
+      - description: signal type slug
+        example: sample-signal--example-org
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: version to be deleted
+        example: 0.0.1
+        in: path
+        name: sem_ver
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      security:
+      - BearerAccessToken: []
+      summary: Delete signal type
+      tags:
+      - Signal types
+    get:
+      description: Returns details about the signal type
+      parameters:
+      - description: ISN slug
+        example: sample-isn--example-org
+        in: path
+        name: isn_slug
+        required: true
+        type: string
+      - description: signal definiton slug
+        example: sample-signal--example-org
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: version to be recieved
+        example: 0.0.1
+        in: path
+        name: sem_ver
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.SignalTypeDetail'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      summary: Get signal type
+      tags:
+      - Signal types
+      - ISN details
+    put:
+      description: |-
+        users can mark the signal type as *in use/not in use* and update the description or link to the readme file
+        Signal types marked as 'not in use' are not returned in signal searches and can not receive new signals
+      parameters:
+      - description: ISN slug
+        example: sample-isn--example-org
+        in: path
+        name: isn_slug
+        required: true
+        type: string
+      - description: signal definiton slug
+        example: sample-signal--example-org
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: Sem ver
+        example: 0.0.1
+        in: path
+        name: sem_ver
+        required: true
+        type: string
+      - description: signal type details to be updated
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.UpdateSignalTypeRequest'
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      security:
+      - BearerAccessToken: []
+      summary: Update signal type
+      tags:
+      - Signal types
   /api/isn/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}/signals/search:
     get:
       description: |-
@@ -1625,129 +1831,6 @@ paths:
       summary: Withdraw a signal
       tags:
       - Signal sharing
-  /api/isn/{isn_slug}/signal_types/{slug}/v{sem_ver}:
-    delete:
-      description: Only signal types that have never been referenced by signals can
-        be deleted
-      parameters:
-      - description: signal type slug
-        example: sample-signal--example-org
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: version to be deleted
-        example: 0.0.1
-        in: path
-        name: sem_ver
-        required: true
-        type: string
-      responses:
-        "204":
-          description: No Content
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "409":
-          description: Conflict
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      security:
-      - BearerAccessToken: []
-      summary: Delete a signal definition
-      tags:
-      - Signal definitions
-    get:
-      parameters:
-      - description: signal definiton slug
-        example: sample-signal--example-org
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: version to be recieved
-        example: 0.0.1
-        in: path
-        name: sem_ver
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/handlers.SignalTypeAndLinkedInfo'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      summary: Get a signal definition
-      tags:
-      - ISN details
-    put:
-      description: |-
-        users can mark the signal type as *in use/not in use* and update the description or link to the readme file
-
-        It is not allowed to update the schema url - instead users should create a new declaration with the same title and bump the version
-      parameters:
-      - description: signal definiton slug
-        example: sample-signal--example-org
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: Sem ver
-        example: 0.0.1
-        in: path
-        name: sem_ver
-        required: true
-        type: string
-      - description: signal type details to be updated
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/handlers.UpdateSignalTypeRequest'
-      responses:
-        "204":
-          description: No Content
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      security:
-      - BearerAccessToken: []
-      summary: Update signal definition
-      tags:
-      - Signal definitions
   /api/isn/{isn_slug}/transfer-ownership:
     put:
       description: |-
@@ -1787,32 +1870,6 @@ paths:
       summary: Transfer ISN ownership
       tags:
       - ISN configuration
-  /api/isn/{slug}:
-    get:
-      description: Returns details about the ISN
-      parameters:
-      - description: isn slug
-        example: sample-isn--example-org
-        in: path
-        name: isn_slug
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/handlers.IsnAndLinkedInfo'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      summary: Get an ISN configurationuration
-      tags:
-      - ISN details
   /api/public/isn/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}/signals/search:
     get:
       description: |-
@@ -1921,11 +1978,13 @@ paths:
 
       parameters:
       - description: ISN slug
+        example: sample-isn--example-org
         in: path
         name: isn_slug
         required: true
         type: string
       - description: Batch ID
+        example: 67890684-3b14-42cf-b785-df28ce570400
         in: path
         name: batch_id
         required: true
@@ -2051,7 +2110,7 @@ paths:
         **Response Status Codes**
         - 200: All signals processed successfully
         - 207: Partial success (some signals succeeded, some failed)
-        - 422: All signals failed processing (returns CreateSignalsResponse with detailed error information)
+        - 422: All signals failed processing (the request was valid but all signals failed processing, e.g because they did not validate against the schema)
         - 400 / error_code = 'malformed_body': Invalid request format, authentication, or other request-level errors
         - 400: authentication, or other request-level errors
         - 500: Internal server errors
@@ -2263,6 +2322,6 @@ tags:
 - description: View information about the configured ISNs
   name: ISN details
 - description: Define the format of the data being shared in an ISN
-  name: Signal definitions
+  name: Signal types
 - description: Manage service account end points
   name: Service accounts

--- a/app/internal/auth/middleware.go
+++ b/app/internal/auth/middleware.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	signalsd "github.com/information-sharing-networks/signalsd/app"
@@ -271,7 +270,7 @@ func (a AuthService) RequireIsnPermission(allowedPermissions ...string) func(htt
 				return
 			}
 
-			isnSlug := chi.URLParam(r, "isn_slug")
+			isnSlug := r.PathValue("isn_slug")
 			if isnSlug == "" {
 				responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeInvalidRequest, "no isn_slug parameter ")
 				return
@@ -311,7 +310,7 @@ func (a AuthService) RequireISNAccessPermission(isPublicISN func(string) bool) f
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger := zerolog.Ctx(r.Context())
 
-			isnSlug := chi.URLParam(r, "isn_slug")
+			isnSlug := r.PathValue("isn_slug")
 			if isnSlug == "" {
 				responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeInvalidRequest, "no isn_slug parameter")
 				return

--- a/app/internal/database/isn.sql.go
+++ b/app/internal/database/isn.sql.go
@@ -7,7 +7,6 @@ package database
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -69,47 +68,6 @@ func (q *Queries) ExistsIsnWithSlug(ctx context.Context, slug string) (bool, err
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err
-}
-
-const GetForDisplayIsnBySlug = `-- name: GetForDisplayIsnBySlug :one
-SELECT 
-    id,
-    created_at,
-    updated_at,
-    title,
-    slug,
-    detail,
-    is_in_use,
-    visibility
-FROM isn 
-WHERE slug = $1
-`
-
-type GetForDisplayIsnBySlugRow struct {
-	ID         uuid.UUID `json:"id"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	Title      string    `json:"title"`
-	Slug       string    `json:"slug"`
-	Detail     string    `json:"detail"`
-	IsInUse    bool      `json:"is_in_use"`
-	Visibility string    `json:"visibility"`
-}
-
-func (q *Queries) GetForDisplayIsnBySlug(ctx context.Context, slug string) (GetForDisplayIsnBySlugRow, error) {
-	row := q.db.QueryRow(ctx, GetForDisplayIsnBySlug, slug)
-	var i GetForDisplayIsnBySlugRow
-	err := row.Scan(
-		&i.ID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.Title,
-		&i.Slug,
-		&i.Detail,
-		&i.IsInUse,
-		&i.Visibility,
-	)
-	return i, err
 }
 
 const GetIsnByID = `-- name: GetIsnByID :one

--- a/app/internal/server/handlers/service_accounts.go
+++ b/app/internal/server/handlers/service_accounts.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	signalsd "github.com/information-sharing-networks/signalsd/app"
 	"github.com/information-sharing-networks/signalsd/app/internal/apperrors"
@@ -295,7 +294,7 @@ func (s *ServiceAccountHandler) RegisterServiceAccountHandler(w http.ResponseWri
 //	@Description
 //	@Tags		Service accounts
 //
-//	@Param		setup_id	path	string	true	"One-time setup ID"
+//	@Param		setup_id	path	string	true	"One-time setup ID"	example(550e8400-e29b-41d4-a716-446655440000)
 //
 //	@Success	201
 //
@@ -306,7 +305,7 @@ func (s *ServiceAccountHandler) RegisterServiceAccountHandler(w http.ResponseWri
 //	@Router		/api/auth/service-accounts/setup/{setup_id} [get]
 func (s *ServiceAccountHandler) SetupServiceAccountHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract token from URL path
-	oneTimeSecretIDString := chi.URLParam(r, "setup_id")
+	oneTimeSecretIDString := r.PathValue("setup_id")
 
 	logger := zerolog.Ctx(r.Context())
 

--- a/app/internal/server/handlers/signal_batches.go
+++ b/app/internal/server/handlers/signal_batches.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/information-sharing-networks/signalsd/app/internal/apperrors"
 	"github.com/information-sharing-networks/signalsd/app/internal/auth"
@@ -179,19 +178,18 @@ func (s *SignalsBatchHandler) CreateSignalsBatchHandler(w http.ResponseWriter, r
 //	@Description
 //	@Description
 //	@Tags		Signal sharing
-//	@Param		isn_slug	path		string	true	"ISN slug"
-//	@Param		batch_id	path		string	true	"Batch ID"
+//	@Param		isn_slug	path		string	true	"ISN slug"		example(sample-isn--example-org)
+//	@Param		batch_id	path		string	true	"Batch ID"		example(67890684-3b14-42cf-b785-df28ce570400)
 //	@Success	200			{object}	BatchStatusResponse
 //	@Failure	400			{object}	responses.ErrorResponse
 //	@Failure	404			{object}	responses.ErrorResponse
 //	@Failure	500			{object}	responses.ErrorResponse
 //	@Router		/isn/{isn_slug}/batches/{batch_id}/status [get]
 //
-// todo handle withdrawn signals
 // todo handle the fact that the list of failed local_refs might be very large if errors go undetected for a long time
 func (s *SignalsBatchHandler) GetSignalBatchStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract path parameters
-	batchIDString := chi.URLParam(r, "batch_id")
+	batchIDString := r.PathValue("batch_id")
 
 	// Parse batch ID
 	batchID, err := uuid.Parse(batchIDString)
@@ -221,7 +219,7 @@ func (s *SignalsBatchHandler) GetSignalBatchStatusHandler(w http.ResponseWriter,
 	}
 
 	// Get the ISN to check if user is an ISN admin
-	isn, err := s.queries.GetIsnBySlug(r.Context(), chi.URLParam(r, "isn_slug"))
+	isn, err := s.queries.GetIsnBySlug(r.Context(), r.PathValue("isn_slug"))
 	if err != nil {
 		responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeDatabaseError, fmt.Sprintf("database error: %v", err))
 		return
@@ -370,7 +368,7 @@ func (s *SignalsBatchHandler) getBatchStatusDetails(ctx context.Context, batchID
 //	@Router			/isn/{isn_slug}/batches/search [get]
 func (s *SignalsBatchHandler) SearchBatchesHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract path parameters
-	isnSlug := chi.URLParam(r, "isn_slug")
+	isnSlug := r.PathValue("isn_slug")
 
 	// check isn exists
 	isn, err := s.queries.GetIsnBySlug(r.Context(), isnSlug)

--- a/app/internal/server/handlers/signals.go
+++ b/app/internal/server/handlers/signals.go
@@ -588,13 +588,13 @@ func (s *SignalsHandler) SearchPublicSignalsHandler(w http.ResponseWriter, r *ht
 //	@Description
 //	@Description	Note the endpoint returns the latest version of each signal and does not include withdrawn or archived signals
 //
-//	@Param			start_date			query		string	false	"Start date for filtering"	example(2006-01-02T15:04:05Z)
-//	@Param			end_date			query		string	false	"End date for filtering"	example(2006-01-02T16:00:00Z
-//	@Param			account_id			query		string	false	"Account ID for filtering"	example(a38c99ed-c75c-4a4a-a901-c9485cf93cf3)
+//	@Param			start_date			query		string	false	"Start date for filtering"						example(2006-01-02T15:04:05Z)
+//	@Param			end_date			query		string	false	"End date for filtering"						example(2006-01-02T16:00:00Z
+//	@Param			account_id			query		string	false	"Account ID for filtering"						example(a38c99ed-c75c-4a4a-a901-c9485cf93cf3)
 //	@Param			include_withdrawn	query		string	false	"Include withdrawn signals (default: false)"	example(false)
 //
-//	@Success		200			{array}		handlers.SignalVersionDoc
-//	@Failure		400			{object}	responses.ErrorResponse
+//	@Success		200					{array}		handlers.SignalVersionDoc
+//	@Failure		400					{object}	responses.ErrorResponse
 //
 //	@Security		BearerAccessToken
 //
@@ -717,9 +717,9 @@ func (s *SignalsHandler) SearchPrivateSignalsHandler(w http.ResponseWriter, r *h
 //
 //	@Tags			Signal sharing
 //
-//	@Param			isn_slug			path	string						true	"ISN slug"				example(sample-isn--example-org)
-//	@Param			signal_type_slug	path	string						true	"Signal type slug"		example(signal-type-1)
-//	@Param			sem_ver				path	string						true	"Signal type version"	example(0.0.1)
+//	@Param			isn_slug			path	string							true	"ISN slug"				example(sample-isn--example-org)
+//	@Param			signal_type_slug	path	string							true	"Signal type slug"		example(signal-type-1)
+//	@Param			sem_ver				path	string							true	"Signal type version"	example(0.0.1)
 //	@Param			request				body	handlers.WithdrawSignalRequest	true	"Withdrawal request"
 //
 //	@Success		204

--- a/app/internal/server/handlers/tokens.go
+++ b/app/internal/server/handlers/tokens.go
@@ -73,7 +73,7 @@ func NewTokenHandler(queries *database.Queries, authService *auth.AuthService, p
 //	@Description
 //	@Tags		auth
 //
-//	@Param		grant_type	query		string							true	"grant type"	Enums(client_credentials, refresh_token)
+//	@Param		grant_type	query		string						true	"grant type"	Enums(client_credentials, refresh_token)
 //	@Param		request		body		ServiceAccountTokenRequest	false	"Service account credentials (required for client_credentials grant)"
 //
 //	@Success	200			{object}	auth.AccessTokenResponse
@@ -268,11 +268,11 @@ func (a *TokenHandler) RevokeRefreshTokenHandler(w http.ResponseWriter, r *http.
 //	@Description
 //	@Tags		auth
 //
-//	@Param		request		body		ServiceAccountTokenRequest	false	"Service account credentials"
+//	@Param		request	body		ServiceAccountTokenRequest	false	"Service account credentials"
 //
-//	@Success	200	{object}	ServiceAccountRotateResponse
-//	@Failure	401	{object}	responses.ErrorResponse	"Authentication failed"
-//	@Failure	500	{object}	responses.ErrorResponse	"Internal server error"
+//	@Success	200		{object}	ServiceAccountRotateResponse
+//	@Failure	401		{object}	responses.ErrorResponse	"Authentication failed"
+//	@Failure	500		{object}	responses.ErrorResponse	"Internal server error"
 //
 //	@Router		/api/auth/service-accounts/rotate-secret [post]
 func (a *TokenHandler) RotateServiceAccountSecretHandler(w http.ResponseWriter, r *http.Request) {

--- a/app/internal/server/server.go
+++ b/app/internal/server/server.go
@@ -214,12 +214,12 @@ func (s *Server) registerAdminRoutes() {
 
 						// ISN management
 						r.Post("/", isn.CreateIsnHandler)
-						r.Put("/i/{isn_slug}", isn.UpdateIsnHandler)
+						r.Put("/{isn_slug}", isn.UpdateIsnHandler)
 
 						// signal types managment
 						r.Post("/{isn_slug}/signal_types", signalTypes.CreateSignalTypeHandler)
-						r.Put("/{isn_slug}/signal_types/{slug}/v{sem_ver}", signalTypes.UpdateSignalTypeHandler)
-						r.Delete("/{isn_slug}/signal_types/{slug}/v{sem_ver}", signalTypes.DeleteSignalTypeHandler)
+						r.Put("/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}", signalTypes.UpdateSignalTypeHandler)
+						r.Delete("/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}", signalTypes.DeleteSignalTypeHandler)
 
 						// ISN account permissions
 						r.Put("/{isn_slug}/accounts/{account_id}", isnAccount.GrantIsnAccountHandler)
@@ -243,7 +243,7 @@ func (s *Server) registerAdminRoutes() {
 					r.Get("/", isn.GetIsnsHandler)
 					r.Get("/{isn_slug}", isn.GetIsnHandler)
 					r.Get("/{isn_slug}/signal_types", signalTypes.GetSignalTypesHandler)
-					r.Get("/{isn_slug}/signal_types/{slug}/v{sem_ver}", signalTypes.GetSignalTypeHandler)
+					r.Get("/{isn_slug}/signal_types/{signal_type_slug}/v{sem_ver}", signalTypes.GetSignalTypeHandler)
 				})
 
 			})

--- a/app/sql/queries/isn.sql
+++ b/app/sql/queries/isn.sql
@@ -49,19 +49,6 @@ WHERE sd.id = $1;
 SELECT i.* 
 FROM isn i;
 
--- name: GetForDisplayIsnBySlug :one
-SELECT 
-    id,
-    created_at,
-    updated_at,
-    title,
-    slug,
-    detail,
-    is_in_use,
-    visibility
-FROM isn 
-WHERE slug = $1;
-
 -- name: ExistsIsnWithSlug :one
 
 SELECT EXISTS

--- a/app/sql/queries/signal_types.sql
+++ b/app/sql/queries/signal_types.sql
@@ -20,10 +20,17 @@ RETURNING *;
 UPDATE signal_types SET (updated_at, readme_url, detail, is_in_use) = (NOW(), $2, $3, $4)
 WHERE id = $1;
 
+
 -- name: GetSignalTypes :many
 
 SELECT st.*
 FROM signal_types st;
+
+-- name: GetSignalTypesByIsnID :many
+
+SELECT st.*
+FROM signal_types st
+WHERE st.isn_id = $1;
 
 
 
@@ -34,50 +41,9 @@ FROM signal_types st
 WHERE st.slug = $1
 AND st.sem_ver = $2;
 
--- name: GetForDisplaySignalTypeByID :one
+-- name: GetSignalTypeByIsnID :many
 SELECT 
-    st.id,
-    st.created_at,
-    st.updated_at,
-    st.slug,
-    st.schema_url,
-    st.readme_url,
-    st.title,
-    st.detail,
-    st.sem_ver,
-    st.is_in_use
-FROM signal_types st
-WHERE st.id = $1;
-
--- name: GetForDisplaySignalTypeBySlug :one
-SELECT 
-    st.id,
-    st.created_at,
-    st.updated_at,
-    st.slug,
-    st.schema_url,
-    st.readme_url,
-    st.title,
-    st.detail,
-    st.sem_ver,
-    st.is_in_use
-FROM signal_types st
-WHERE st.slug = $1
-  AND st.sem_ver = $2;
-
-
--- name: GetForDisplaySignalTypeByIsnID :many
-SELECT 
-    st.id,
-    st.created_at,
-    st.updated_at,
-    st.slug,
-    st.schema_url,
-    st.readme_url,
-    st.title,
-    st.detail,
-    st.sem_ver,
-    st.is_in_use
+    st.*
 FROM signal_types st
 WHERE st.isn_id = $1;
 
@@ -115,7 +81,7 @@ SELECT EXISTS
 
 
 
--- name: CheckSignalTypeInUse :one
+-- name: CheckSignalTypeHasSignals :one
 SELECT EXISTS(
     SELECT 1
     FROM signals

--- a/app/sql/queries/users.sql
+++ b/app/sql/queries/users.sql
@@ -1,5 +1,3 @@
--- note: don't display emails on public apis ("GetForDisplay*").
-
 -- name: CreateUser :one
 INSERT INTO users (account_id, created_at, updated_at, email, hashed_password, user_role)
 VALUES ( $1, NOW(), NOW(), $2, $3, 'member')
@@ -21,16 +19,10 @@ SELECT * FROM users WHERE email = $1;
 SELECT u.account_id, u.email, u.user_role, u.created_at , u.updated_at FROM users u;
 
 -- name: GetUserByID :one
-SELECT  u.account_id, u.email, u.user_role, u.created_at  FROM users u WHERE u.account_id = $1;
+SELECT  u.account_id, u.email, u.user_role, u.created_at , u.updated_at FROM users u WHERE u.account_id = $1;
 
--- name: GetForDisplayUserBySignalDefID :one
-SELECT u.account_id, u.created_at , u.updated_at 
-FROM users u 
-JOIN signal_types sd ON u.account_id = sd.user_account_id 
-WHERE sd.id = $1;
-
--- name: GetForDisplayUserByIsnID :one
-SELECT u.account_id, u.created_at , u.updated_at 
+-- name: GetUserByIsnID :one
+SELECT u.*
 FROM users u 
 JOIN isn i ON u.account_id = i.user_account_id 
 WHERE i.id = $1;


### PR DESCRIPTION
- isn, isn_accounts, admin and singal_type handers now user explicit struct defs in json responses
- bug fix: signal type GET handlers were returning all isn types; admin refactor
- added missing swaggo URL param annotations
- url params slug params renamed to avoid ambiguous use of "slug"
- switched the remaining Chi url parameter extractions to use standard library method instead