### PR TITLE
Limit access to generate password links

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The app uses the following external tools:
 
 All these tools are installed as part of the docker image.
 
-The Docker app is started with Air which will restart the service whenever you save changes to the code.  Air is configured to automatically run goose/sqlc/swag after each change.
+The Docker app is started with Air which will restart the service whenever you save changes to the code.  Air is configured to automatically run sqlc and swag after each change.  Database migrations are applied when you restart the docker app container (if you ar running locally, you will need to run the migrations manually - see the section on goose below)
 
 If you need to run these tools individually, you can use the Makefile for common tasks:
 

--- a/app/docs/docs.go
+++ b/app/docs/docs.go
@@ -424,7 +424,7 @@ const docTemplate = `{
                         "BearerAccessToken": []
                     }
                 ],
-                "description": "Allows admins to generate a one-time password reset link for a user (use this endpoint when a user has forgotten their password)\nThe generated link expires in 30 minutes and can only be used once.",
+                "description": "Allows admins or the site owner to generate a one-time password reset link for a user (use this endpoint when a user has forgotten their password)\n\nThe generated link can be used to reset the password of the associated account using the page rendered by the PasswordResetTokenPageHandler.\nThe generated link expires in 30 minutes and can only be used once.\n\nAdmins can create links on behalf of users with a member role.  The site owner role can create links for admins and members.\n\n**Note:** The generated link can be used by any user in possession of the link to reset the password of the associated account.\nThe link should be treated as sensitive and protected accordingly.",
                 "tags": [
                     "Site Admin"
                 ],
@@ -561,11 +561,11 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Processes a password reset request with a valid reset token\nValidates the token, updates the user's password, and consumes the token",
+                "description": "Endpoint to handle password requests received from the PasswordResetTokenPageHandler (do not call the endpoint directly)\nThe handler validates the token, updates the user password, and consumes the one-time-use token.\nAny user in possession of the token can use it to reset the password of the associated account\nOne time tokens can only be issued by admins or the site owner.",
                 "tags": [
                     "auth"
                 ],
-                "summary": "Process password reset",
+                "summary": "Process password reset token",
                 "parameters": [
                     {
                         "type": "string",
@@ -621,7 +621,7 @@ const docTemplate = `{
                 "tags": [
                     "auth"
                 ],
-                "summary": "Password reset",
+                "summary": "Password reset (self service)",
                 "parameters": [
                     {
                         "description": "user details",

--- a/app/docs/swagger.json
+++ b/app/docs/swagger.json
@@ -415,7 +415,7 @@
                         "BearerAccessToken": []
                     }
                 ],
-                "description": "Allows admins to generate a one-time password reset link for a user (use this endpoint when a user has forgotten their password)\nThe generated link expires in 30 minutes and can only be used once.",
+                "description": "Allows admins or the site owner to generate a one-time password reset link for a user (use this endpoint when a user has forgotten their password)\n\nThe generated link can be used to reset the password of the associated account using the page rendered by the PasswordResetTokenPageHandler.\nThe generated link expires in 30 minutes and can only be used once.\n\nAdmins can create links on behalf of users with a member role.  The site owner role can create links for admins and members.\n\n**Note:** The generated link can be used by any user in possession of the link to reset the password of the associated account.\nThe link should be treated as sensitive and protected accordingly.",
                 "tags": [
                     "Site Admin"
                 ],
@@ -552,11 +552,11 @@
                 }
             },
             "post": {
-                "description": "Processes a password reset request with a valid reset token\nValidates the token, updates the user's password, and consumes the token",
+                "description": "Endpoint to handle password requests received from the PasswordResetTokenPageHandler (do not call the endpoint directly)\nThe handler validates the token, updates the user password, and consumes the one-time-use token.\nAny user in possession of the token can use it to reset the password of the associated account\nOne time tokens can only be issued by admins or the site owner.",
                 "tags": [
                     "auth"
                 ],
-                "summary": "Process password reset",
+                "summary": "Process password reset token",
                 "parameters": [
                     {
                         "type": "string",
@@ -612,7 +612,7 @@
                 "tags": [
                     "auth"
                 ],
-                "summary": "Password reset",
+                "summary": "Password reset (self service)",
                 "parameters": [
                     {
                         "description": "user details",

--- a/app/docs/swagger.yaml
+++ b/app/docs/swagger.yaml
@@ -1209,8 +1209,15 @@ paths:
   /api/admin/users/{user_id}/generate-password-reset-link:
     post:
       description: |-
-        Allows admins to generate a one-time password reset link for a user (use this endpoint when a user has forgotten their password)
+        Allows admins or the site owner to generate a one-time password reset link for a user (use this endpoint when a user has forgotten their password)
+
+        The generated link can be used to reset the password of the associated account using the page rendered by the PasswordResetTokenPageHandler.
         The generated link expires in 30 minutes and can only be used once.
+
+        Admins can create links on behalf of users with a member role.  The site owner role can create links for admins and members.
+
+        **Note:** The generated link can be used by any user in possession of the link to reset the password of the associated account.
+        The link should be treated as sensitive and protected accordingly.
       parameters:
       - description: User Account ID
         example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
@@ -1315,8 +1322,10 @@ paths:
       - auth
     post:
       description: |-
-        Processes a password reset request with a valid reset token
-        Validates the token, updates the user's password, and consumes the token
+        Endpoint to handle password requests received from the PasswordResetTokenPageHandler (do not call the endpoint directly)
+        The handler validates the token, updates the user password, and consumes the one-time-use token.
+        Any user in possession of the token can use it to reset the password of the associated account
+        One time tokens can only be issued by admins or the site owner.
       parameters:
       - description: Password reset token ID
         example: 550e8400-e29b-41d4-a716-446655440000
@@ -1345,7 +1354,7 @@ paths:
           description: Gone
           schema:
             $ref: '#/definitions/responses.ErrorResponse'
-      summary: Process password reset
+      summary: Process password reset token
       tags:
       - auth
   /api/auth/password/reset:
@@ -1372,7 +1381,7 @@ paths:
             $ref: '#/definitions/responses.ErrorResponse'
       security:
       - BearerAccessToken: []
-      summary: Password reset
+      summary: Password reset (self service)
       tags:
       - auth
   /api/auth/register:

--- a/app/internal/server/config/config.go
+++ b/app/internal/server/config/config.go
@@ -129,6 +129,25 @@ func NewServerConfig() (*ServerConfig, *CORSConfigs, error) {
 	return &cfg, corsConfigs, nil
 }
 
+// GetPublicBaseURL returns the appropriate base URL for user-facing links.
+// The default value is based on the request TLS and Host header information.
+// Where X-Forwarded-Proto and X-Forwarded-Host are set by a reverse proxy these are used instead.
+func GetPublicBaseURL(r *http.Request) string {
+	scheme := "http"
+	if forwardedProto := r.Header.Get("X-Forwarded-Proto"); forwardedProto != "" {
+		scheme = forwardedProto
+	} else if r.TLS != nil {
+		scheme = "https"
+	}
+
+	host := r.Host
+	if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
+		host = forwardedHost
+	}
+
+	return fmt.Sprintf("%s://%s", scheme, host)
+}
+
 // validateConfig checks for required env variables
 func validateConfig(cfg *ServerConfig) error {
 	if cfg.Environment == "prod" {

--- a/app/internal/server/handlers/admin.go
+++ b/app/internal/server/handlers/admin.go
@@ -15,7 +15,6 @@ import (
 	"github.com/information-sharing-networks/signalsd/app/internal/logger"
 	signalsd "github.com/information-sharing-networks/signalsd/app/internal/server/config"
 	"github.com/information-sharing-networks/signalsd/app/internal/server/responses"
-	"github.com/information-sharing-networks/signalsd/app/internal/server/utils"
 	"github.com/information-sharing-networks/signalsd/app/internal/version"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -792,10 +791,9 @@ func (a *AdminHandler) GeneratePasswordResetLinkHandler(w http.ResponseWriter, r
 		return
 	}
 
-	// Generate the one-time password reset URL (following service account pattern)
-	resetURL := fmt.Sprintf("%s://%s/api/auth/password-reset/%s",
-		utils.GetScheme(r),
-		r.Host,
+	// Generate the one-time password reset URL using forwarded headers
+	resetURL := fmt.Sprintf("%s/api/auth/password-reset/%s",
+		signalsd.GetPublicBaseURL(r),
 		tokenID.String(),
 	)
 

--- a/app/internal/server/handlers/admin.go
+++ b/app/internal/server/handlers/admin.go
@@ -708,8 +708,15 @@ type GeneratePasswordResetLinkResponse struct {
 // GeneratePasswordResetLinkHandler godoc
 //
 //	@Summary		Generate password reset link
-//	@Description	Allows admins to generate a one-time password reset link for a user (use this endpoint when a user has forgotten their password)
+//	@Description	Allows admins or the site owner to generate a one-time password reset link for a user (use this endpoint when a user has forgotten their password)
+//	@Description
+//	@Description	The generated link can be used to reset the password of the associated account using the page rendered by the PasswordResetTokenPageHandler.
 //	@Description	The generated link expires in 30 minutes and can only be used once.
+//	@Description
+//	@Description	Admins can create links on behalf of users with a member role.  The site owner role can create links for admins and members.
+//	@Description
+//	@Description	**Note:** The generated link can be used by any user in possession of the link to reset the password of the associated account.
+//	@Description	The link should be treated as sensitive and protected accordingly.
 //	@Tags			Site Admin
 //
 //	@Param			user_id	path		string	true	"User Account ID"	example(a38c99ed-c75c-4a4a-a901-c9485cf93cf3)
@@ -723,30 +730,44 @@ type GeneratePasswordResetLinkResponse struct {
 //	@Security		BearerAccessToken
 //
 //	@Router			/api/admin/users/{user_id}/generate-password-reset-link [post]
+//
+//	this handler must use the RequireRole (admin/owner) middleware
 func (a *AdminHandler) GeneratePasswordResetLinkHandler(w http.ResponseWriter, r *http.Request) {
 
-	// Get admin account ID from context (set by middleware)
-	adminAccountID, ok := auth.ContextAccountID(r.Context())
+	// Get account ID from context (set by middleware)
+	accountID, ok := auth.ContextAccountID(r.Context())
 	if !ok {
-		responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeInternalError, "admin account ID not found in context")
+		responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeInternalError, "account ID not found in context")
+		return
+	}
+
+	// verify the account generating the request is an admin or owner
+	claims, ok := auth.ContextClaims(r.Context())
+	if !ok {
+		responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeInternalError, "could not get claims from context")
+		return
+	}
+
+	if claims.Role != "owner" && claims.Role != "admin" {
+		responses.RespondWithError(w, r, http.StatusForbidden, apperrors.ErrCodeForbidden, "you do not have permission to generate password reset links")
 		return
 	}
 
 	// Get user ID from URL parameter
-	userIDStr := r.PathValue("user_id")
-	if userIDStr == "" {
+	tagetUserIDStr := r.PathValue("user_id")
+	if tagetUserIDStr == "" {
 		responses.RespondWithError(w, r, http.StatusBadRequest, apperrors.ErrCodeInvalidURLParam, "user_id parameter is required")
 		return
 	}
 
-	userID, err := uuid.Parse(userIDStr)
+	tagetUserID, err := uuid.Parse(tagetUserIDStr)
 	if err != nil {
 		responses.RespondWithError(w, r, http.StatusBadRequest, apperrors.ErrCodeInvalidURLParam, "invalid user_id format")
 		return
 	}
 
 	// Verify user exists
-	user, err := a.queries.GetUserByID(r.Context(), userID)
+	user, err := a.queries.GetUserByID(r.Context(), tagetUserID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			responses.RespondWithError(w, r, http.StatusNotFound, apperrors.ErrCodeResourceNotFound, "user not found")
@@ -754,19 +775,24 @@ func (a *AdminHandler) GeneratePasswordResetLinkHandler(w http.ResponseWriter, r
 		}
 		logger.ContextWithLogAttrs(r.Context(),
 			slog.String("error", err.Error()),
-			slog.String("user_id", userID.String()),
+			slog.String("user_id", tagetUserID.String()),
 		)
 
 		responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeDatabaseError, "database error")
 		return
 	}
 
+	// admins can only update members
+	if claims.Role == "admin" && user.UserRole != "member" {
+		responses.RespondWithError(w, r, http.StatusForbidden, apperrors.ErrCodeForbidden, "admins cannot generate password reset for other admins or site owners")
+		return
+	}
 	// Delete any existing password reset tokens for this user (following service account pattern)
-	_, err = a.queries.DeletePasswordResetTokensForUser(r.Context(), userID)
+	_, err = a.queries.DeletePasswordResetTokensForUser(r.Context(), tagetUserID)
 	if err != nil {
 		logger.ContextWithLogAttrs(r.Context(),
 			slog.String("error", err.Error()),
-			slog.String("user_id", userID.String()),
+			slog.String("user_id", tagetUserID.String()),
 		)
 
 		responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeDatabaseError, "database error")
@@ -777,14 +803,14 @@ func (a *AdminHandler) GeneratePasswordResetLinkHandler(w http.ResponseWriter, r
 	expiresAt := time.Now().Add(signalsd.PasswordResetExpiry)
 	tokenID, err := a.queries.CreatePasswordResetToken(r.Context(), database.CreatePasswordResetTokenParams{
 		ID:               uuid.New(),
-		UserAccountID:    userID,
+		UserAccountID:    tagetUserID,
 		ExpiresAt:        expiresAt,
-		CreatedByAdminID: adminAccountID,
+		CreatedByAdminID: accountID,
 	})
 	if err != nil {
 		logger.ContextWithLogAttrs(r.Context(),
 			slog.String("error", err.Error()),
-			slog.String("user_id", userID.String()),
+			slog.String("user_id", tagetUserID.String()),
 		)
 
 		responses.RespondWithError(w, r, http.StatusInternalServerError, apperrors.ErrCodeDatabaseError, "database error")
@@ -800,14 +826,14 @@ func (a *AdminHandler) GeneratePasswordResetLinkHandler(w http.ResponseWriter, r
 	// Add reset URL and account ID to final request log context
 	logger.ContextWithLogAttrs(r.Context(),
 		slog.String("reset_url", resetURL),
-		slog.String("user_id", userID.String()),
-		slog.String("admin_account_id", adminAccountID.String()),
+		slog.String("user_id", tagetUserID.String()),
+		slog.String("admin_account_id", accountID.String()),
 	)
 
 	// Return the reset link information
 	response := GeneratePasswordResetLinkResponse{
 		UserEmail: user.Email,
-		AccountID: userID,
+		AccountID: tagetUserID,
 		ResetURL:  resetURL,
 		ExpiresAt: expiresAt,
 		ExpiresIn: int(signalsd.PasswordResetExpiry.Seconds()),

--- a/app/internal/server/handlers/isn.go
+++ b/app/internal/server/handlers/isn.go
@@ -221,9 +221,8 @@ func (i *IsnHandler) CreateIsnHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resourceURL := fmt.Sprintf("%s://%s/api/isn/%s",
-		utils.GetScheme(r),
-		r.Host,
+	resourceURL := fmt.Sprintf("%s/api/isn/%s",
+		signalsd.GetPublicBaseURL(r),
 		slug,
 	)
 

--- a/app/internal/server/handlers/service_accounts.go
+++ b/app/internal/server/handlers/service_accounts.go
@@ -232,10 +232,9 @@ func (s *ServiceAccountHandler) RegisterServiceAccountHandler(w http.ResponseWri
 		return
 	}
 
-	// Generate the one-time setup URL
-	setupURL := fmt.Sprintf("%s://%s/api/auth/service-accounts/setup/%s",
-		utils.GetScheme(r),
-		r.Host,
+	// Generate the one-time setup URL using forwarded headers
+	setupURL := fmt.Sprintf("%s/api/auth/service-accounts/setup/%s",
+		signalsd.GetPublicBaseURL(r),
 		oneTimeSecretID.String(),
 	)
 
@@ -405,10 +404,9 @@ func (s *ServiceAccountHandler) ReissueServiceAccountCredentialsHandler(w http.R
 		return
 	}
 
-	// Generate the one-time setup URL
-	setupURL := fmt.Sprintf("%s://%s/api/auth/service-accounts/setup/%s",
-		utils.GetScheme(r),
-		r.Host,
+	// Generate the one-time setup URL using forwarded headers
+	setupURL := fmt.Sprintf("%s/api/auth/service-accounts/setup/%s",
+		signalsd.GetPublicBaseURL(r),
 		oneTimeSecretID.String(),
 	)
 

--- a/app/internal/server/handlers/signal_batches.go
+++ b/app/internal/server/handlers/signal_batches.go
@@ -13,6 +13,7 @@ import (
 	"github.com/information-sharing-networks/signalsd/app/internal/auth"
 	"github.com/information-sharing-networks/signalsd/app/internal/database"
 	"github.com/information-sharing-networks/signalsd/app/internal/logger"
+	signalsd "github.com/information-sharing-networks/signalsd/app/internal/server/config"
 	"github.com/information-sharing-networks/signalsd/app/internal/server/responses"
 	"github.com/information-sharing-networks/signalsd/app/internal/server/utils"
 	"github.com/jackc/pgx/v5"
@@ -166,9 +167,8 @@ func (s *SignalsBatchHandler) CreateSignalsBatchHandler(w http.ResponseWriter, r
 		return
 	}
 
-	resourceURL := fmt.Sprintf("%s://%s/api/isn/%s/account/%s/batch/%s",
-		utils.GetScheme(r),
-		r.Host,
+	resourceURL := fmt.Sprintf("%s/api/isn/%s/account/%s/batch/%s",
+		signalsd.GetPublicBaseURL(r),
 		isnSlug,
 		account.ID,
 		returnedRow.ID,

--- a/app/internal/server/handlers/signal_types.go
+++ b/app/internal/server/handlers/signal_types.go
@@ -330,9 +330,8 @@ func (s *SignalTypeHandler) CreateSignalTypeHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	resourceURL := fmt.Sprintf("%s://%s/api/isn/%s/signal_types/%s/v%s",
-		utils.GetScheme(r),
-		r.Host,
+	resourceURL := fmt.Sprintf("%s/api/isn/%s/signal_types/%s/v%s",
+		signalsd.GetPublicBaseURL(r),
 		isn.Slug,
 		slug,
 		semVer,

--- a/app/internal/server/server.go
+++ b/app/internal/server/server.go
@@ -224,11 +224,12 @@ func (s *Server) registerAdminRoutes() {
 					r.Post("/service-accounts/rotate-secret", tokens.RotateServiceAccountSecretHandler)
 				})
 
+				// no authentication required
 				r.Post("/register", users.RegisterUserHandler)
 				r.Post("/login", login.LoginHandler)
 				r.Get("/service-accounts/setup/{setup_id}", serviceAccounts.SetupServiceAccountHandler)
-				r.Get("/password-reset/{token_id}", users.PasswordResetPageHandler)
-				r.Post("/password-reset/{token_id}", users.PasswordResetHandler)
+				r.Get("/password-reset/{token_id}", users.PasswordResetTokenPageHandler)
+				r.Post("/password-reset/{token_id}", users.PasswordResetTokenHandler)
 			})
 
 			// isn admin endpoints

--- a/app/internal/server/templates/auth/password_reset_form.templ
+++ b/app/internal/server/templates/auth/password_reset_form.templ
@@ -11,7 +11,7 @@ type PasswordResetPageData struct {
 	ExpiresIn time.Duration
 }
 
-templ PasswordResetPage(data PasswordResetPageData) {
+templ PasswordResetTokenPage(data PasswordResetPageData) {
 	<!DOCTYPE html>
 	<html>
 		<head>

--- a/app/internal/server/templates/auth/password_reset_form_templ.go
+++ b/app/internal/server/templates/auth/password_reset_form_templ.go
@@ -19,7 +19,7 @@ type PasswordResetPageData struct {
 	ExpiresIn time.Duration
 }
 
-func PasswordResetPage(data PasswordResetPageData) templ.Component {
+func PasswordResetTokenPage(data PasswordResetPageData) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/app/internal/server/utils/utils.go
+++ b/app/internal/server/utils/utils.go
@@ -185,18 +185,6 @@ func IncrementSemVer(bump_type string, semVer string) (string, error) {
 	return fmt.Sprintf("%d.%d.%d", major, minor, patch), nil
 }
 
-func GetScheme(r *http.Request) string {
-	if r.TLS != nil {
-		return "https"
-	}
-
-	// Check common reverse proxy headers
-	if scheme := r.Header.Get("X-Forwarded-Proto"); scheme != "" {
-		return scheme
-	}
-	return "http"
-}
-
 // check for valid origins, e.g http://localhost:8080 , https://example.com etc
 func IsValidOrigin(urlStr string) bool {
 	re := regexp.MustCompile(`^(https?):\/\/([a-zA-Z0-9_\-\.]+)(:\d+)?$`)


### PR DESCRIPTION
Previously admins could generate links for any account - they are now limited to resetting member accounts only.  The site owner can reset both members and admins.