### PR TITLE
new PUBLIC_BASE_URL environment config

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -8,10 +8,11 @@ on:
   workflow_dispatch:
 
 env:
-  # Secrets 
+  # Mandatory environment settings 
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   SECRET_KEY: ${{ secrets.SECRET_KEY }}
   GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  PUBLIC_BASE_URL: ${{ vars.PUBLIC_BASE_URL }}
 
   # Service configuration 
   ENVIRONMENT: prod
@@ -90,6 +91,7 @@ jobs:
           ENV_VARS="${ENV_VARS},SECRET_KEY=${{ env.SECRET_KEY }}"
           ENV_VARS="${ENV_VARS},ENVIRONMENT=${{ env.ENVIRONMENT }}"
           ENV_VARS="${ENV_VARS},LOG_LEVEL=${{ env.LOG_LEVEL }}"
+          ENV_VARS="${ENV_VARS},PUBLIC_BASE_URL=${{ env.PUBLIC_BASE_URL }}"
 
           # Add optional configuration variables only if they are set 
           if [ -n "${{ vars.DB_MAX_CONNECTIONS }}" ]; then

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -11,10 +11,11 @@ on:
   workflow_dispatch:
 
 env:
-  # Secrets
+  # mandatory environment settings
   STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
   STAGING_SECRET_KEY: ${{ secrets.STAGING_SECRET_KEY }}
   GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  STAGING_PUBLIC_BASE_URL: ${{ vars.STAGING_PUBLIC_BASE_URL }}
 
   # Service configuration
   ENVIRONMENT: staging
@@ -95,6 +96,7 @@ jobs:
           ENV_VARS="${ENV_VARS},SECRET_KEY=${{ env.STAGING_SECRET_KEY }}"
           ENV_VARS="${ENV_VARS},ENVIRONMENT=${{ env.ENVIRONMENT }}"
           ENV_VARS="${ENV_VARS},LOG_LEVEL=${{ env.LOG_LEVEL }}"
+          ENV_VARS="${ENV_VARS},PUBLIC_BASE_URL=${{ env.STAGING_PUBLIC_BASE_URL }}"
 
           # Add optional configuration variables only if they are set
           if [ -n "${{ vars.DB_MAX_CONNECTIONS }}" ]; then

--- a/README.md
+++ b/README.md
@@ -60,36 +60,36 @@ The service has sensible defaults for all configuration values. You only need to
 ```bash
 # Required (for production and local dev environments)
 DATABASE_URL=postgres://user:password@host:port/database?sslmode=disable # note production urls must use ssl.
-SECRET_KEY=your-random-secret-key-here  # Generate with: openssl rand -base64 64
+SECRET_KEY=your-random-secret-key-here # Generate with: openssl rand -base64 64
+PUBLIC_BASE_URL=https://yourdomain.com # Base URL for user facing links(e.g one-time password links (default: http://localhost:8080)
 
 # Server Configuration (all optional - defaults shown)
-HOST=0.0.0.0                    # Bind address (default: 0.0.0.0)
-PORT=8080                       # Server port (default: 8080)
-ENVIRONMENT=dev                 # Options: dev, prod, test, perf, staging (default: dev)
-LOG_LEVEL=debug                 # Options: debug, info, warn, error (default: debug)
+HOST=0.0.0.0                          # Bind address (default: 0.0.0.0)
+PORT=8080                             # Server port (default: 8080)
+ENVIRONMENT=dev                       #  Options: dev, prod, test, perf, staging (default: dev)
+LOG_LEVEL=debug                       #  Options: debug, info, warn, error (default: debug)
 
 # Performance Tuning (all optional - defaults shown)
-READ_TIMEOUT=15s                # HTTP read timeout (default: 15s)
-WRITE_TIMEOUT=15s               # HTTP write timeout (default: 15s)
-IDLE_TIMEOUT=60s                # HTTP idle timeout (default: 60s)
-RATE_LIMIT_RPS=100              # Requests per second (default: 100, set to 0 to disable)
-RATE_LIMIT_BURST=20             # Burst allowance (default: 20)
-MAX_SIGNAL_PAYLOAD_SIZE=5242880 # Max payload size (default: 5MB)
-MAX_API_REQUEST_SIZE=65536      # Max API request size (default: 64KB)
+READ_TIMEOUT=15s                      #  HTTP read timeout (default: 15s)
+WRITE_TIMEOUT=15s                     #  HTTP write timeout (default: 15s)
+IDLE_TIMEOUT=60s                      #  HTTP idle timeout (default: 60s)
+RATE_LIMIT_RPS=100                    #  Requests per second (default: 100, set to 0 to disable)
+RATE_LIMIT_BURST=20                   #  Burst allowance (default: 20)
+MAX_SIGNAL_PAYLOAD_SIZE=5242880       #  Max payload size (default: 5MB)
+MAX_API_REQUEST_SIZE=65536            #  Max API request size (default: 64KB)
 
 # Security - list sites that are allowed to use the service
-ALLOWED_ORIGINS=*               # CORS origins (default: *, comma-separated for multiple)
+ALLOWED_ORIGINS=*                     #  CORS origins (default: *, comma-separated for multiple)
 
 # Database Connection Pool (the default used are the same as those used by pgx )
 DB_MAX_CONNECTIONS=4
-DB_MIN_CONNECTIONS=0            # Allow scaling to zero (Cloud Run)
+DB_MIN_CONNECTIONS=0                  #  Allow scaling to zero (Cloud Run)
 DB_MAX_CONN_LIFETIME=60m
 DB_MAX_CONN_IDLE_TIME=30m
 DB_CONNECT_TIMEOUT=5s
 ```
 
 **Note**: In the Docker development environment, DATABASE_URL and SECRET_KEY are automatically configured with development-appropriate defaults. In production you should use a secret management service to supply these two settings.
-
 
 
 ## Quick Start (Docker Development Environment)
@@ -133,7 +133,7 @@ PORT=8081 docker compose up app
 ENVIRONMENT=perf DB_MAX_CONNECTIONS=50 DB_MIN_CONNECTIONS=5 RATE_LIMIT_RPS=0 docker compose up app
 
 # Production-like configuration
-ENVIRONMENT=prod DB_MAX_CONNECTIONS=25 DB_CONNECT_TIMEOUT=10s RATE_LIMIT_RPS=200 docker compose up app
+ENVIRONMENT=prod PUBLIC_BASE_URL=https://yourdomain.com DB_MAX_CONNECTIONS=25 DB_CONNECT_TIMEOUT=10s RATE_LIMIT_RPS=200 docker compose up app
 
 # Rebuild the image when you change:
 # - dockerfile_inline content
@@ -309,7 +309,7 @@ PORT=8081 go run cmd/signalsd/main.go --mode all
 ENVIRONMENT=perf DB_MAX_CONNECTIONS=50 DB_MIN_CONNECTIONS=5 RATE_LIMIT_RPS=0 go run cmd/signalsd/main.go --mode all
 
 # Production-like settings
-ENVIRONMENT=prod DB_MAX_CONNECTIONS=25 DB_CONNECT_TIMEOUT=10s go run cmd/signalsd/main.go --mode all
+PUBLIC_BASE_URL=https://yourdomain.com ENVIRONMENT=prod DB_MAX_CONNECTIONS=25 DB_CONNECT_TIMEOUT=10s go run cmd/signalsd/main.go --mode all
 ```
 
 ## User Interface
@@ -487,6 +487,14 @@ You will need three secrets:
 if you are deploying to a staging environment you need to create a separate database and two additional secrets:
 - `STAGING_DATABASE_URL`
 - `STAGING_SECRET_KEY`
+
+You need to create a single github environment variable to hold the public base url for your app:
+- `PUBLIC_BASE_URL` (e.g. https://yourdomain.com)
+
+If you are deploying to a staging environment you need to create a separate variable to hold the public base url:
+- `STAGING_PUBLIC_BASE_URL` (e.g. https://staging.yourdomain.com)
+
+The public base URL is used by the back-end server when generating password reset and service account setup links.
 
 #### DNS
 google will automatically assign a *.run.app domain name to your Gcloud run service(s) and these can be mapped to custom domains using Google Cloud run DNS (see https://cloud.google.com/run/docs/mapping-custom-domains)

--- a/app/cmd/signalsd/main.go
+++ b/app/cmd/signalsd/main.go
@@ -189,6 +189,7 @@ func run(mode string) error {
 		slog.String("ENVIRONMENT", cfg.Environment),
 		slog.String("HOST", cfg.Host),
 		slog.Int("PORT", cfg.Port),
+		slog.String("PUBLIC_BASE_URL", cfg.PublicBaseURL),
 		slog.String("LOG_LEVEL", cfg.LogLevel),
 		slog.Duration("READ_TIMEOUT", cfg.ReadTimeout),
 		slog.Duration("WRITE_TIMEOUT", cfg.WriteTimeout),

--- a/app/docs/docs.go
+++ b/app/docs/docs.go
@@ -2496,10 +2496,6 @@ const docTemplate = `{
         "handlers.CreateSignalTypeResponse": {
             "type": "object",
             "properties": {
-                "resource_url": {
-                    "type": "string",
-                    "example": "http://localhost:8080/api/isn/sample-isn--example-org/signals_types/sample-signal--example-org/v0.0.1"
-                },
                 "sem_ver": {
                     "type": "string",
                     "example": "0.0.1"
@@ -2516,10 +2512,6 @@ const docTemplate = `{
                 "account_id": {
                     "type": "string",
                     "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
-                },
-                "resource_url": {
-                    "type": "string",
-                    "example": "http://localhost:8080/api/isn/sample-isn--example-org/account/{account_id}/batch/{signals_batch_id}"
                 },
                 "signals_batch_id": {
                     "type": "string",

--- a/app/docs/swagger.json
+++ b/app/docs/swagger.json
@@ -2487,10 +2487,6 @@
         "handlers.CreateSignalTypeResponse": {
             "type": "object",
             "properties": {
-                "resource_url": {
-                    "type": "string",
-                    "example": "http://localhost:8080/api/isn/sample-isn--example-org/signals_types/sample-signal--example-org/v0.0.1"
-                },
                 "sem_ver": {
                     "type": "string",
                     "example": "0.0.1"
@@ -2507,10 +2503,6 @@
                 "account_id": {
                     "type": "string",
                     "example": "a38c99ed-c75c-4a4a-a901-c9485cf93cf3"
-                },
-                "resource_url": {
-                    "type": "string",
-                    "example": "http://localhost:8080/api/isn/sample-isn--example-org/account/{account_id}/batch/{signals_batch_id}"
                 },
                 "signals_batch_id": {
                     "type": "string",

--- a/app/docs/swagger.yaml
+++ b/app/docs/swagger.yaml
@@ -248,9 +248,6 @@ definitions:
     type: object
   handlers.CreateSignalTypeResponse:
     properties:
-      resource_url:
-        example: http://localhost:8080/api/isn/sample-isn--example-org/signals_types/sample-signal--example-org/v0.0.1
-        type: string
       sem_ver:
         example: 0.0.1
         type: string
@@ -262,9 +259,6 @@ definitions:
     properties:
       account_id:
         example: a38c99ed-c75c-4a4a-a901-c9485cf93cf3
-        type: string
-      resource_url:
-        example: http://localhost:8080/api/isn/sample-isn--example-org/account/{account_id}/batch/{signals_batch_id}
         type: string
       signals_batch_id:
         example: b51faf05-aaed-4250-b334-2258ccdf1ff2

--- a/app/go.mod
+++ b/app/go.mod
@@ -26,6 +26,7 @@ require (
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
+	github.com/Netflix/go-env v0.1.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -1,5 +1,7 @@
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/Netflix/go-env v0.1.2 h1:0DRoLR9lECQ9Zqvkswuebm3jJ/2enaDX6Ei8/Z+EnK0=
+github.com/Netflix/go-env v0.1.2/go.mod h1:WlIhYi++8FlKNJtrop1mjXYAJMzv1f43K4MqCoh0yGE=
 github.com/a-h/templ v0.3.943 h1:o+mT/4yqhZ33F3ootBiHwaY4HM5EVaOJfIshvd5UNTY=
 github.com/a-h/templ v0.3.943/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/app/internal/logger/logger.go
+++ b/app/internal/logger/logger.go
@@ -88,6 +88,8 @@ func ParseLogLevel(level string) slog.Level {
 		return slog.LevelWarn
 	case "error":
 		return slog.LevelError
+	case "none":
+		return 100
 	default:
 		return slog.LevelDebug
 	}

--- a/app/internal/server/handlers/admin.go
+++ b/app/internal/server/handlers/admin.go
@@ -21,16 +21,18 @@ import (
 )
 
 type AdminHandler struct {
-	queries     *database.Queries
-	pool        *pgxpool.Pool
-	authService *auth.AuthService
+	queries       *database.Queries
+	pool          *pgxpool.Pool
+	authService   *auth.AuthService
+	publicBaseURL string
 }
 
-func NewAdminHandler(queries *database.Queries, pool *pgxpool.Pool, authService *auth.AuthService) *AdminHandler {
+func NewAdminHandler(queries *database.Queries, pool *pgxpool.Pool, authService *auth.AuthService, publicBaseURL string) *AdminHandler {
 	return &AdminHandler{
-		queries:     queries,
-		pool:        pool,
-		authService: authService,
+		queries:       queries,
+		pool:          pool,
+		authService:   authService,
+		publicBaseURL: publicBaseURL,
 	}
 }
 
@@ -820,7 +822,7 @@ func (a *AdminHandler) GeneratePasswordResetLinkHandler(w http.ResponseWriter, r
 
 	// Generate the one-time password reset URL using forwarded headers
 	resetURL := fmt.Sprintf("%s/api/auth/password-reset/%s",
-		signalsd.GetPublicBaseURL(r),
+		a.publicBaseURL,
 		tokenID.String(),
 	)
 

--- a/app/internal/server/handlers/isn.go
+++ b/app/internal/server/handlers/isn.go
@@ -22,14 +22,16 @@ import (
 )
 
 type IsnHandler struct {
-	queries *database.Queries
-	pool    *pgxpool.Pool
+	queries       *database.Queries
+	pool          *pgxpool.Pool
+	publicBaseURL string
 }
 
-func NewIsnHandler(queries *database.Queries, pool *pgxpool.Pool) *IsnHandler {
+func NewIsnHandler(queries *database.Queries, pool *pgxpool.Pool, publicBaseURL string) *IsnHandler {
 	return &IsnHandler{
-		queries: queries,
-		pool:    pool,
+		queries:       queries,
+		pool:          pool,
+		publicBaseURL: publicBaseURL,
 	}
 }
 
@@ -222,7 +224,7 @@ func (i *IsnHandler) CreateIsnHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resourceURL := fmt.Sprintf("%s/api/isn/%s",
-		signalsd.GetPublicBaseURL(r),
+		i.publicBaseURL,
 		slug,
 	)
 

--- a/app/internal/server/handlers/service_accounts.go
+++ b/app/internal/server/handlers/service_accounts.go
@@ -24,16 +24,18 @@ import (
 )
 
 type ServiceAccountHandler struct {
-	queries     *database.Queries
-	authService *auth.AuthService
-	pool        *pgxpool.Pool
+	queries       *database.Queries
+	authService   *auth.AuthService
+	pool          *pgxpool.Pool
+	publicBaseURL string
 }
 
-func NewServiceAccountHandler(queries *database.Queries, authService *auth.AuthService, pool *pgxpool.Pool) *ServiceAccountHandler {
+func NewServiceAccountHandler(queries *database.Queries, authService *auth.AuthService, pool *pgxpool.Pool, publicBaseURL string) *ServiceAccountHandler {
 	return &ServiceAccountHandler{
-		queries:     queries,
-		authService: authService,
-		pool:        pool,
+		queries:       queries,
+		authService:   authService,
+		pool:          pool,
+		publicBaseURL: publicBaseURL,
 	}
 }
 
@@ -234,7 +236,7 @@ func (s *ServiceAccountHandler) RegisterServiceAccountHandler(w http.ResponseWri
 
 	// Generate the one-time setup URL using forwarded headers
 	setupURL := fmt.Sprintf("%s/api/auth/service-accounts/setup/%s",
-		signalsd.GetPublicBaseURL(r),
+		s.publicBaseURL,
 		oneTimeSecretID.String(),
 	)
 
@@ -295,6 +297,7 @@ func (s *ServiceAccountHandler) ReissueServiceAccountCredentialsHandler(w http.R
 	}
 
 	if req.ClientID == "" {
+
 		responses.RespondWithError(w, r, http.StatusBadRequest, apperrors.ErrCodeMalformedBody, "client_id is required")
 		return
 	}
@@ -406,7 +409,7 @@ func (s *ServiceAccountHandler) ReissueServiceAccountCredentialsHandler(w http.R
 
 	// Generate the one-time setup URL using forwarded headers
 	setupURL := fmt.Sprintf("%s/api/auth/service-accounts/setup/%s",
-		signalsd.GetPublicBaseURL(r),
+		s.publicBaseURL,
 		oneTimeSecretID.String(),
 	)
 

--- a/app/internal/server/handlers/signal_batches.go
+++ b/app/internal/server/handlers/signal_batches.go
@@ -13,7 +13,6 @@ import (
 	"github.com/information-sharing-networks/signalsd/app/internal/auth"
 	"github.com/information-sharing-networks/signalsd/app/internal/database"
 	"github.com/information-sharing-networks/signalsd/app/internal/logger"
-	signalsd "github.com/information-sharing-networks/signalsd/app/internal/server/config"
 	"github.com/information-sharing-networks/signalsd/app/internal/server/responses"
 	"github.com/information-sharing-networks/signalsd/app/internal/server/utils"
 	"github.com/jackc/pgx/v5"
@@ -32,7 +31,6 @@ type CreateSignalsBatchRequest struct {
 }
 
 type CreateSignalsBatchResponse struct {
-	ResourceURL    string    `json:"resource_url" example:"http://localhost:8080/api/isn/sample-isn--example-org/account/{account_id}/batch/{signals_batch_id}"`
 	AccountID      uuid.UUID `json:"account_id" example:"a38c99ed-c75c-4a4a-a901-c9485cf93cf3"`
 	SignalsBatchID uuid.UUID `json:"signals_batch_id" example:"b51faf05-aaed-4250-b334-2258ccdf1ff2"`
 }
@@ -167,19 +165,11 @@ func (s *SignalsBatchHandler) CreateSignalsBatchHandler(w http.ResponseWriter, r
 		return
 	}
 
-	resourceURL := fmt.Sprintf("%s/api/isn/%s/account/%s/batch/%s",
-		signalsd.GetPublicBaseURL(r),
-		isnSlug,
-		account.ID,
-		returnedRow.ID,
-	)
-
 	logger.ContextWithLogAttrs(r.Context(),
 		slog.String("batch_id", returnedRow.ID.String()),
 	)
 
 	responses.RespondWithJSON(w, http.StatusOK, CreateSignalsBatchResponse{
-		ResourceURL:    resourceURL,
 		AccountID:      account.ID,
 		SignalsBatchID: returnedRow.ID,
 	})

--- a/app/internal/server/handlers/signal_types.go
+++ b/app/internal/server/handlers/signal_types.go
@@ -38,9 +38,8 @@ type CreateSignalTypeRequest struct {
 }
 
 type CreateSignalTypeResponse struct {
-	Slug        string `json:"slug" example:"sample-signal--example-org"`
-	SemVer      string `json:"sem_ver" example:"0.0.1"`
-	ResourceURL string `json:"resource_url" example:"http://localhost:8080/api/isn/sample-isn--example-org/signals_types/sample-signal--example-org/v0.0.1"`
+	Slug   string `json:"slug" example:"sample-signal--example-org"`
+	SemVer string `json:"sem_ver" example:"0.0.1"`
 }
 
 type UpdateSignalTypeRequest struct {
@@ -330,17 +329,9 @@ func (s *SignalTypeHandler) CreateSignalTypeHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	resourceURL := fmt.Sprintf("%s/api/isn/%s/signal_types/%s/v%s",
-		signalsd.GetPublicBaseURL(r),
-		isn.Slug,
-		slug,
-		semVer,
-	)
-
 	responses.RespondWithJSON(w, http.StatusCreated, CreateSignalTypeResponse{
-		Slug:        returnedSignalType.Slug,
-		SemVer:      returnedSignalType.SemVer,
-		ResourceURL: resourceURL,
+		Slug:   returnedSignalType.Slug,
+		SemVer: returnedSignalType.SemVer,
 	})
 }
 

--- a/app/internal/server/responses/response.go
+++ b/app/internal/server/responses/response.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/information-sharing-networks/signalsd/app/internal/apperrors"
+	"github.com/information-sharing-networks/signalsd/app/internal/logger"
 )
 
 type ErrorResponse struct {
@@ -34,6 +35,9 @@ func RespondWithError(w http.ResponseWriter, r *http.Request, statusCode int, er
 		_, _ = w.Write([]byte(`{"error_code":"internal_error","message":"Internal Server Error"}`))
 		return
 	}
+
+	// add user message to the final log message
+	logger.ContextWithLogAttrs(r.Context(), slog.String("message", message), slog.String("error_code", errorCode.String()))
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(statusCode)

--- a/app/internal/ui/client/register.go
+++ b/app/internal/ui/client/register.go
@@ -97,8 +97,6 @@ func (c *Client) LookupServiceAccountByClientID(accessToken, clientID string) (*
 	// Use the admin service accounts endpoint to get all service accounts, then filter by client_id
 	// This is similar to how the user lookup works but for service accounts
 
-	fmt.Printf("debug !!!! LookupServiceAccountByClientID: %s\n", clientID)
-
 	url := fmt.Sprintf("%s/api/admin/service-accounts?client_id=%s", c.baseURL, clientID)
 
 	req, err := http.NewRequest("GET", url, nil)

--- a/app/test/integration/cors_test.go
+++ b/app/test/integration/cors_test.go
@@ -50,7 +50,7 @@ func TestCORS(t *testing.T) {
 	testDB := setupTestDatabase(t, ctx)
 	testEnv := setupTestEnvironment(testDB)
 	testDatabaseURL := getTestDatabaseURL()
-	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testDatabaseURL)
+	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testDatabaseURL, "")
 	privateEndpoint := baseURL + "/api/accounts"
 	publicEndpoint := baseURL + "/health/live"
 

--- a/app/test/integration/oauth_test.go
+++ b/app/test/integration/oauth_test.go
@@ -32,7 +32,7 @@ func TestOAuthTokenEndpoint(t *testing.T) {
 
 	// Start server
 	testURL := getTestDatabaseURL()
-	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL)
+	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL, "")
 	defer stopServer()
 
 	t.Log("Creating test data...")
@@ -417,7 +417,7 @@ func TestOAuthRevokeEndpoint(t *testing.T) {
 
 	// Start server
 	testURL := getTestDatabaseURL()
-	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL)
+	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL, "")
 	defer stopServer()
 
 	t.Log("Creating test data...")

--- a/app/test/integration/signal_test.go
+++ b/app/test/integration/signal_test.go
@@ -387,7 +387,7 @@ func TestSignalSubmission(t *testing.T) {
 
 	// select database and start the signalsd server
 	testURL := getTestDatabaseURL()
-	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL)
+	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL, "")
 	defer stopServer()
 	t.Logf("✅ Server started at %s", baseURL)
 
@@ -807,7 +807,7 @@ func TestIsInUseStatus(t *testing.T) {
 
 	// select database and start the signalsd server
 	testURL := getTestDatabaseURL()
-	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL)
+	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL, "")
 	defer stopServer()
 	t.Logf("✅ Server started at %s", baseURL)
 
@@ -1074,7 +1074,7 @@ func TestSignalSearch(t *testing.T) {
 
 	// note that the server must be started after the test data is created so the public isn cache is populated
 	testURL := getTestDatabaseURL()
-	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL)
+	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL, "")
 	defer stopServer()
 	t.Logf("✅ Server started at %s", baseURL)
 
@@ -1382,7 +1382,7 @@ func TestCorrelatedAndPreviousVersionsSearch(t *testing.T) {
 
 	// select database and start the signalsd server
 	testURL := getTestDatabaseURL()
-	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL)
+	baseURL, stopServer := startInProcessServer(t, ctx, testEnv.dbConn, testURL, "")
 	defer stopServer()
 	t.Logf("✅ Server started at %s", baseURL)
 


### PR DESCRIPTION
this var is used to set the public url used when creating the public urls used for password resets and issuing service account credentials (this is safer than trying to work out the domain name in the client api)

- switched to netflix/go-env
- fixed naming on reisse_login_reset tests which prvented the test running
- fixed the integration test config option to enable detailed logs when tests run
- fied the reissue service account tests to work with the new API request format
- included user error message with final log of request that result in a na error